### PR TITLE
Remove service-control in validate_release.py

### DIFF
--- a/script/validate_release.py
+++ b/script/validate_release.py
@@ -67,7 +67,6 @@ RUN_TESTS = [
     'long-run-test_gke-tight-http2-interop',
     'long-run-test_gke-tight-https-bookstore',
     'release',
-    'service-control',
     'tsan',
 ]
 


### PR DESCRIPTION
Service-control test was originally run unit-tests from service-control-client-cxx.  
It was removed. 