### PR TITLE
Add GetRequestPath to Request.h.

### DIFF
--- a/src/nginx/request.cc
+++ b/src/nginx/request.cc
@@ -47,6 +47,11 @@ std::string NgxEspRequest::GetQueryParameters() {
   return ngx_str_to_std(r_->args);
 }
 
+std::string NgxEspRequest::GetRequestPath() {
+  std::string unparsed_str = ngx_str_to_std(r_->unparsed_uri);
+  return unparsed_str.substr(0, unparsed_str.find_first_of('?'));
+}
+
 std::string NgxEspRequest::GetUnparsedRequestPath() {
   return ngx_str_to_std(r_->unparsed_uri);
 }

--- a/src/nginx/request.h
+++ b/src/nginx/request.h
@@ -46,6 +46,7 @@ class NgxEspRequest : public Request {
   virtual std::string GetQueryParameters();
   virtual protocol::Protocol GetFrontendProtocol();
   virtual protocol::Protocol GetBackendProtocol();
+  virtual std::string GetRequestPath();
   virtual std::string GetUnparsedRequestPath();
   virtual std::string GetClientIP();
 


### PR DESCRIPTION
Adding this method back. The method now returns the unparsed path without the query parameters.