### PR TITLE
Update NGINX to 1.13.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,7 +31,7 @@ ESP_TOOL = "ff0d6df7f56ca1c2b229aaadd8abe62cb1d508fb"
 
 git_repository(
     name = "nginx",
-    commit = "cfce863dbe786e61e0e7a33376906b337da70c19",
+    commit = "8324948a670df2d2da89be0be25fcdce18142fed", # v1.13.2
     remote = "https://nginx.googlesource.com/nginx",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -32,7 +32,7 @@ ESP_TOOL = "ff0d6df7f56ca1c2b229aaadd8abe62cb1d508fb"
 
 git_repository(
     name = "nginx",
-    commit = "8324948a670df2d2da89be0be25fcdce18142fed",  # v1.13.2
+    commit = "4cc41a4aeefa580ca8a86a7fe251838d60bc6ce5",  # v1.13.3
     remote = "https://nginx.googlesource.com/nginx",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,11 +27,12 @@
 # A Bazel (http://bazel.io) workspace for the Google Cloud Endpoints runtime.
 
 ISTIO_PROXY = "b129798546b499db2966921f4ba4dc53bb56bd5c"
+
 ESP_TOOL = "ff0d6df7f56ca1c2b229aaadd8abe62cb1d508fb"
 
 git_repository(
     name = "nginx",
-    commit = "8324948a670df2d2da89be0be25fcdce18142fed", # v1.13.2
+    commit = "8324948a670df2d2da89be0be25fcdce18142fed",  # v1.13.2
     remote = "https://nginx.googlesource.com/nginx",
 )
 
@@ -162,7 +163,7 @@ git_repository(
 #
 git_repository(
     name = "io_bazel_rules_go",
-    commit = "2d9f328a9723baf2d037ba9db28d9d0e30683938", # Apr 6, 2017 (buildifier fix)
+    commit = "2d9f328a9723baf2d037ba9db28d9d0e30683938",  # Apr 6, 2017 (buildifier fix)
     remote = "https://github.com/bazelbuild/rules_go.git",
 )
 

--- a/src/nginx/main/testdata/copyright-expected
+++ b/src/nginx/main/testdata/copyright-expected
@@ -286,9 +286,9 @@ NGINX license:
 ==============
 
 /*
- * Copyright (C) 2002-2016 Igor Sysoev
- * Copyright (C) 2011-2016 Nginx, Inc.
- * Copyright (C) 2015-2016 Google Inc.
+ * Copyright (C) 2002-2017 Igor Sysoev
+ * Copyright (C) 2011-2017 Nginx, Inc.
+ * Copyright (C) 2015-2017 Google Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -344,7 +344,7 @@ Email domain:     cam.ac.uk
 University of Cambridge Computing Service,
 Cambridge, England.
 
-Copyright (c) 1997-2016 University of Cambridge
+Copyright (c) 1997-2017 University of Cambridge
 All rights reserved.
 
 
@@ -355,7 +355,7 @@ Written by:       Zoltan Herczeg
 Email local part: hzmester
 Emain domain:     freemail.hu
 
-Copyright(c) 2010-2016 Zoltan Herczeg
+Copyright(c) 2010-2017 Zoltan Herczeg
 All rights reserved.
 
 
@@ -366,7 +366,7 @@ Written by:       Zoltan Herczeg
 Email local part: hzmester
 Emain domain:     freemail.hu
 
-Copyright(c) 2009-2016 Zoltan Herczeg
+Copyright(c) 2009-2017 Zoltan Herczeg
 All rights reserved.
 
 
@@ -877,7 +877,7 @@ zlib license:
 
 Copyright notice:
 
- (C) 1995-2013 Jean-loup Gailly and Mark Adler
+ (C) 1995-2017 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/src/nginx/module.cc
+++ b/src/nginx/module.cc
@@ -967,12 +967,12 @@ void ngx_http_esp_exit_timer_event_handler(ngx_event_t *ev) {
 
   ngx_cycle_t *cycle = reinterpret_cast<ngx_cycle_t *>(ev->data);
 
-  if (!ngx_exiting && !ngx_terminate) {
+  if (!ngx_exiting && !ngx_terminate && !ngx_quit) {
     ngx_esp_schedule_exit_timer(cycle, ev);
   } else if (!ngx_esp_attempt_shutdown(cycle)) {
     // The shutdown attempt hasn't succeeded yet. Reschedule timer again
     // with shorter timeout to give shutdown more time to complete.
-    shutdown_timeout = 1;
+    shutdown_timeout = 10;
     ngx_esp_schedule_exit_timer(cycle, ev);
   }
 }

--- a/src/nginx/module.cc
+++ b/src/nginx/module.cc
@@ -113,12 +113,6 @@ void *ngx_esp_create_main_conf(ngx_conf_t *cf);
 // Initializes the modules' main context configuration structure.
 char *ngx_esp_init_main_conf(ngx_conf_t *cf, void *conf);
 
-// Create server context configuration.
-void *ngx_esp_create_srv_conf(ngx_conf_t *cf);
-
-// Merges in parent server configuration.
-char *ngx_esp_merge_srv_conf(ngx_conf_t *cf, void *prev, void *conf);
-
 // Creates the module's location context configuration structure.
 void *ngx_esp_create_loc_conf(ngx_conf_t *cf);
 char *ngx_esp_merge_loc_conf(ngx_conf_t *cf, void *parent, void *child);
@@ -183,14 +177,22 @@ ngx_command_t ngx_esp_commands[] = {
     },
     {
         ngx_string("endpoints_resolver"), NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
-        ngx_conf_set_str_slot, NGX_HTTP_MAIN_CONF_OFFSET,
-        offsetof(ngx_esp_main_conf_t, upstream_resolver), nullptr,
+        [](ngx_conf_t *cf, ngx_command_t *cmd, void *conf) -> char * {
+          return ngx_conf_set_str_slot(
+              cf, cmd, &reinterpret_cast<ngx_esp_main_conf_t *>(conf)
+                            ->upstream_resolver);
+        },
+        NGX_HTTP_MAIN_CONF_OFFSET, 0, nullptr,
     },
     {
         ngx_string("endpoints_certificates"),
-        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1, ngx_conf_set_str_slot,
-        NGX_HTTP_MAIN_CONF_OFFSET, offsetof(ngx_esp_main_conf_t, cert_path),
-        nullptr,
+        NGX_HTTP_MAIN_CONF | NGX_CONF_TAKE1,
+        [](ngx_conf_t *cf, ngx_command_t *cmd, void *conf) -> char * {
+          return ngx_conf_set_str_slot(
+              cf, cmd,
+              &reinterpret_cast<ngx_esp_main_conf_t *>(conf)->cert_path);
+        },
+        NGX_HTTP_MAIN_CONF_OFFSET, 0, nullptr,
     },
     ngx_null_command  // last entry
 };
@@ -938,23 +940,9 @@ bool ngx_esp_attempt_shutdown(ngx_cycle_t *cycle) {
 }
 
 // The shutdown timeout.
+// The module schedules a short timeout to detect NGINX shutdown.
 //
-// The module schedules a very long timeout to detect NGINX shutdown. During
-// shutdown, NGINX cancels timers and calls their handlers.
-//
-// The value of NGX_MAX_INT32_VALUE (2147483647 ms, or approximately 24 days)
-// is used for the timeout because it is long enough (24 days) but also
-// confirmed to work on Mac OSX.
-//
-// Too high a timeout (for example NGX_MAX_INT_T_VALUE) will cause kevent to
-// return an invalid argument error which effectively disables the NGINX event
-// loop by turning into a perpetually failing infinite loop.
-//
-// The largest value confirmed to work on Mac OSX is:
-//   NGX_MAX_INT_T_VALUE >> 27 == 68719476735
-// which is approximately 795 days.
-//
-const ngx_msec_t shutdown_timeout = NGX_MAX_INT32_VALUE;
+ngx_msec_t shutdown_timeout = 500;
 
 // Forward declaration.
 void ngx_http_esp_exit_timer_event_handler(ngx_event_t *ev);
@@ -969,7 +957,6 @@ void ngx_esp_schedule_exit_timer(ngx_cycle_t *cycle, ngx_event_t *ev) {
   ev->data = cycle;
   ev->handler = ngx_http_esp_exit_timer_event_handler;
   ev->log = cycle->log;
-  ev->cancelable = 1;
 
   ngx_add_timer(ev, shutdown_timeout);
 }
@@ -980,13 +967,12 @@ void ngx_http_esp_exit_timer_event_handler(ngx_event_t *ev) {
 
   ngx_cycle_t *cycle = reinterpret_cast<ngx_cycle_t *>(ev->data);
 
-  if (ev->timedout) {
-    // Timer timed out. This should be exceedingly rare (the shutdown timeout is
-    // very long). If it does happen, reschedule the same timeout again.
+  if (!ngx_exiting && !ngx_terminate) {
     ngx_esp_schedule_exit_timer(cycle, ev);
   } else if (!ngx_esp_attempt_shutdown(cycle)) {
-    // Timer was cancelled but the shutdown attempt hasn't succeeded yet.
-    // Reschedule timer again to give shutdown more time to complete.
+    // The shutdown attempt hasn't succeeded yet. Reschedule timer again
+    // with shorter timeout to give shutdown more time to complete.
+    shutdown_timeout = 1;
     ngx_esp_schedule_exit_timer(cycle, ev);
   }
 }

--- a/src/nginx/t/no_service_control.t
+++ b/src/nginx/t/no_service_control.t
@@ -58,6 +58,8 @@ daemon off;
 events {
   worker_connections 32;
 }
+worker_shutdown_timeout 10s;
+debug_points abort;
 http {
   %%TEST_GLOBALS_HTTP%%
   server_tokens off;

--- a/src/nginx/t/no_service_control.t
+++ b/src/nginx/t/no_service_control.t
@@ -58,8 +58,6 @@ daemon off;
 events {
   worker_connections 32;
 }
-worker_shutdown_timeout 10s;
-debug_points abort;
 http {
   %%TEST_GLOBALS_HTTP%%
   server_tokens off;

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -38,15 +38,24 @@ perl_library(
 # Nginx test suite containing all of the integration tests
 # included with Nginx.
 
-# ssl_sni_reneg.t is excluded from the test suite because boring ssl
-# does not support renegotiation feature required by the test.
 
 nginx_suite(
     nginx = "//src/nginx/main:nginx-esp",
     tags = ["exclusive"],
     tests = glob(
         ["nginx-tests/*.t"],
-        exclude = ["nginx-tests/ssl_sni_reneg.t"],
+        exclude = [
+            # limit_req.t is excluded from the test suite because we use 429
+            # instead of 503 as response status code
+            "nginx-tests/limit_req.t",
+            # ssl2.t is excluded from the test suite because boring ssl
+            # does not support SSL_get0_raw_cipherlist used by $ssl_ciphers
+            # variable required by the test.
+            "nginx-tests/ssl2.t",
+            # ssl_sni_reneg.t is excluded from the test suite because boring ssl
+            # does not support renegotiation feature required by the test.
+            "nginx-tests/ssl_sni_reneg.t",
+        ],
     ),
     deps = [
         ":nginx_test",


### PR DESCRIPTION
- Removed unused function prototype
- Fix undefined behavior of offset() on non-POD types
- Fix the shutdown timer logic which works on newer NGINX since 1.11.11