### PR TITLE
fix gke custom e2e test.

### DIFF
--- a/test/bookstore/gke/nginx.conf
+++ b/test/bookstore/gke/nginx.conf
@@ -42,8 +42,7 @@ http {
       # Begin Endpoints v2 Support
       endpoints {
         on;
-        server_config /etc/nginx/server_config.pb.txt;
-        api /etc/nginx/endpoints/service.json;
+        server_config /etc/nginx/endpoints/server_config.pb.txt;
       }
       # End Endpoints v2 Support
 


### PR DESCRIPTION
This nginx config file is passed into gke as custom nginx config in custom e2e test.

service_config now is in /etc/nginx/endpoints/server_config.pb.txt
api is not needed. downloaded service config file path is stored in server_config.pb.txt