### PR TITLE
add rollout strategy to the service name.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -581,7 +581,7 @@ def e2eGKE(coupling, proto, backend = 'bookstore') {
 def e2eGCE(vmImage, rolloutStrategy) {
   setupNode()
   fastUnstash('tools')
-  def commonOptions = e2eCommonOptions('gce-raw')
+  def commonOptions = e2eCommonOptions('gce-raw', rolloutStrategy)
   def espDebianPkg = espDebianPackage()
   def debianPackageRepo = getDebianPackageRepo()
   echo('Running GCE test')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -581,6 +581,7 @@ def e2eGKE(coupling, proto, backend = 'bookstore') {
 def e2eGCE(vmImage, rolloutStrategy) {
   setupNode()
   fastUnstash('tools')
+  // Use different service names for tests with different strategy.
   def commonOptions = e2eCommonOptions('gce-raw', rolloutStrategy)
   def espDebianPkg = espDebianPackage()
   def debianPackageRepo = getDebianPackageRepo()


### PR DESCRIPTION
For GCE tests,  GCE has two E2E tests; fixed and managed.  But they both use the same service name.
The tests are run parallel.  when both are trying to deploy a service,   they could step over each other, cause the last step rollout to fail.