### PR TITLE
Retry crashed grpc test client.

### DIFF
--- a/script/linux-grpc-test-long-run
+++ b/script/linux-grpc-test-long-run
@@ -110,18 +110,20 @@ function grpc_test_pass_through() {
           --requests_per_stream="${STREAM_COUNT}" \
           --random_payload_max_size="${RANDOM_PAYLOAD_SIZE}" \
           --random_payload_max_size="${RANDOM_PAYLOAD_SIZE}" > "${tmp_file}"
-      # gRPC test client occasionally aborted. Retry.
+      # gRPC test client occasionally aborted. Retry up to 5 times.
+      local count=0
       while : ; do
           cat "${tmp_file}" |"${ROOT}/bazel-bin/test/grpc/grpc-test-client"
           local status=$?
           if [[ "$status" == "0" ]]; then
               break
           fi
-          if [[ "$status" != "134" ]]; then
+          if [[ "$status" != "134" ]] || [[ ${count} -gt 5 ]]; then
               ((failures++))
               break
           fi
-          echo "Test client crashed, Retry the test."
+          ((count++))
+          echo "Test client crashed, Retry the test: ${count}"
       done
   done
   return $failures

--- a/script/linux-grpc-test-long-run
+++ b/script/linux-grpc-test-long-run
@@ -95,6 +95,7 @@ function generate_run_config() {
 function grpc_test_pass_through() {
   echo "Starting grpc pass through stress test at $(date)."
 
+  local tmp_file="$(mktemp)"
   local failures=0
   for run in $(seq 1 ${ALL_CONFIG_TYPES}); do
       generate_run_config $((run - 1))
@@ -108,7 +109,20 @@ function grpc_test_pass_through() {
           --concurrent="${CONCURRENT}" \
           --requests_per_stream="${STREAM_COUNT}" \
           --random_payload_max_size="${RANDOM_PAYLOAD_SIZE}" \
-          |"${ROOT}/bazel-bin/test/grpc/grpc-test-client" || ((failures++))
+          --random_payload_max_size="${RANDOM_PAYLOAD_SIZE}" > "${tmp_file}"
+      # gRPC test client occasionally aborted. Retry.
+      while : ; do
+          cat "${tmp_file}" |"${ROOT}/bazel-bin/test/grpc/grpc-test-client"
+          local status=$?
+          if [[ "$status" == "0" ]]; then
+              break
+          fi
+          if [[ "$status" != "134" ]]; then
+              ((failures++))
+              break
+          fi
+          echo "Test client crashed, Retry the test."
+      done
   done
   return $failures
 }


### PR DESCRIPTION
grpc test is flaky due to its test client occasionally crashed at

 2068 channel_cc.cc:136]          assertion failed: GRPC_CALL_OK == grpc_call_start_batch(call->call(), cops, nops, ops, nullptr)

retry the test if the client is crashed.