### PR TITLE
Fix outdated endpoints container registry

### DIFF
--- a/doc/k8s/README.md
+++ b/doc/k8s/README.md
@@ -65,7 +65,7 @@ values returned when you deployed the API:
 
         containers:
         - name: esp
-          image: b.gcr.io/endpoints/endpoints-runtime:0.3
+          image: gcr.io/endpoints-release/endpoints-runtime:1
           command: [
             "/usr/sbin/start_esp.py",
             "-p", "8080",

--- a/doc/k8s/esp_echo_http.yaml
+++ b/doc/k8s/esp_echo_http.yaml
@@ -54,7 +54,7 @@ spec:
             secretName: service-account-creds
       containers:
         - name: esp
-          image: b.gcr.io/endpoints/endpoints-runtime:0.3
+          image: gcr.io/endpoints-release/endpoints-runtime:1
           command: [
             "/usr/sbin/start_esp.py",
             "-p", "8080",


### PR DESCRIPTION
The endpoints container registry "b.gcr.io/endpoints/endpoints-runtime:0.3" has
been deprecated. In this fix, the deprecated container registry is updated
to the correct endpoints container registry.