### PR TITLE
Added always_print_primitive_fields experimental option (#227)

### DIFF
--- a/include/api_manager/api_manager.h
+++ b/include/api_manager/api_manager.h
@@ -75,6 +75,9 @@ class ApiManager {
   // This function checks server_config for that flag.
   virtual bool get_logging_status_disabled() = 0;
 
+  // server_config experimental option to print primitive fields in JSON output
+  virtual bool get_always_print_primitive_fields() = 0;
+
   // Creates a RequestHandler to handle check and report for each request.
   // Its usage:
   //  1) Creates a RequestHandler object for each request,

--- a/src/api_manager/api_manager_impl.h
+++ b/src/api_manager/api_manager_impl.h
@@ -49,6 +49,10 @@ class ApiManagerImpl : public ApiManager {
     return global_context_->DisableLogStatus();
   };
 
+  bool get_always_print_primitive_fields() override {
+    return global_context_->AlwaysPrintPrimitiveFields();
+  };
+
   utils::Status GetStatistics(ApiManagerStatistics *statistics) const override;
 
   // Add a new service config.

--- a/src/api_manager/context/global_context.h
+++ b/src/api_manager/context/global_context.h
@@ -70,6 +70,14 @@ class GlobalContext {
     return false;
   }
 
+  bool AlwaysPrintPrimitiveFields() {
+    if (server_config() && server_config()->has_experimental()) {
+      const auto &experimental = server_config()->experimental();
+      return experimental.always_print_primitive_fields();
+    }
+    return false;
+  }
+
   // report interval can be override by server_config.
   int64_t intermediate_report_interval() const {
     return intermediate_report_interval_;

--- a/src/api_manager/proto/server_config.proto
+++ b/src/api_manager/proto/server_config.proto
@@ -224,4 +224,6 @@ message ApiServiceConfig {
 message Experimental {
   // Disable timed printouts of ESP status to the error log.
   bool disable_log_status = 1;
+  // Configure response to JSON translator option for JsonPrintOptions:
+  bool always_print_primitive_fields = 2;
 }

--- a/src/grpc/transcoding/transcoder_factory.h
+++ b/src/grpc/transcoding/transcoder_factory.h
@@ -20,6 +20,7 @@
 #include "google/api/service.pb.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "google/protobuf/stubs/status.h"
+#include "google/protobuf/util/json_util.h"
 #include "grpc_transcoding/transcoder.h"
 #include "grpc_transcoding/transcoder_input_stream.h"
 #include "grpc_transcoding/type_helper.h"
@@ -60,7 +61,9 @@ namespace transcoding {
 class TranscoderFactory {
  public:
   // service - The service config for which the factory is created
-  TranscoderFactory(const ::google::api::Service& service_config);
+  TranscoderFactory(const ::google::api::Service& service_config,
+                    const ::google::protobuf::util::JsonPrintOptions& json_print_options =
+                          ::google::protobuf::util::JsonPrintOptions());
 
   // Creates a Transcoder object to transcode a single client request
   // call_info - contains all the necessary info for setting up transcoding
@@ -77,6 +80,7 @@ class TranscoderFactory {
 
  private:
   ::google::grpc::transcoding::TypeHelper type_helper_;
+  ::google::protobuf::util::JsonPrintOptions json_print_options_;
 };
 
 }  // namespace transcoding

--- a/src/nginx/module.cc
+++ b/src/nginx/module.cc
@@ -113,8 +113,12 @@ ngx_esp_request_ctx_s::ngx_esp_request_ctx_s(ngx_http_request_t *r,
     if (it != lc->transcoder_factory_map.end()) {
       transcoder_factory = it->second;
     } else {
+      ::google::protobuf::util::JsonPrintOptions json_print_options = ::google::protobuf::util::JsonPrintOptions();
+      if (lc->esp->get_always_print_primitive_fields()) {
+        json_print_options.always_print_primitive_fields = true;
+      }
       transcoder_factory = std::make_shared<transcoding::TranscoderFactory>(
-          lc->esp->service(config_id));
+          lc->esp->service(config_id), json_print_options);
       lc->transcoder_factory_map[config_id] = transcoder_factory;
     }
   }


### PR DESCRIPTION
@lizan Here is the pull request as recommended in https://github.com/cloudendpoints/esp/issues/227

We are currently unable to verify the change as we have a few unknowns:
1. We do not have a means to produce a docker image, the documentation does not mention how to build this and it appears it requires a ".deb" package. I assume we are missing one or more build steps.
2. Does building the package and docker image require a specific operating system and/or version?
3. We are not aware of how to specify the "server config" or these "experimental" options when starting the service through the start_esp script.