### PR TITLE
Add packages for ESP building and tests, and ESP building guide on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ To download the Extensible Service Proxy source code, clone the ESP repository:
 
 To find out more about building, running, and testing ESP, please review
 
+* [Build ESP on Ubuntu 16.04](/doc/build-esp-on-ubuntu-16-04.md)
 * [ESP Tutorial](/doc/tutorial.md)
 * [Testing ESP with Bazel](/doc/testing.md)
 * [Run ESP on Kubernetes](/doc/k8s/README.md)

--- a/doc/build-esp-on-ubuntu-16-04.md
+++ b/doc/build-esp-on-ubuntu-16-04.md
@@ -1,0 +1,60 @@
+# Build ESP on Ubuntu 16.04 #
+
+This tutorial includes detailed instructions for building
+ESP and running ESP tests on Ubuntu 16.04.
+
+# Prerequisites #
+
+Install Ubuntu 16.04 LTS OS.
+
+Install the following software packages:
+
+    # Software packages needed for building ESP
+    sudo apt-get install -y \
+         g++ git openjdk-8-jdk openjdk-8-source \
+         pkg-config unzip uuid-dev zip zlib1g-dev
+
+    # Software packages needed for building ESP
+    sudo apt-get install libtool m4 autotools-dev automake
+         
+## Install bazel ##
+
+ESP is built using the [bazel](http://bazel.io) build tool. 
+Follow the bazel [install instructions](https://docs.bazel.build/versions/master/install-ubuntu.html#install-using-binary-installer) to install bazel. 
+ESP currently requires bazel 0.5.4. For bazel 0.5.4 on Ubuntu, 
+the binary installer is bazel-0.5.4-installer-linux-x86_64.sh.
+
+*Note:* Bazel is under active development and from time to time, ESP continuous
+integration systems are upgraded to a new version of Bazel. 
+The version of Bazel used by ESP continuous integration systems can be found in
+the [linux-install-software](/script/linux-install-software)
+script variable `BAZEL_VERSION=<SHA>`.
+
+# Build ESP #
+
+To build ESP, run the following commands in the terminal .
+
+    # Clone the ESP repository
+    git clone https://github.com/cloudendpoints/esp
+
+    cd esp
+
+    # Initialize Git submodules
+    git submodule update --init --recursive
+
+    # Build ESP binary
+    bazel build //src/nginx/main:nginx-esp
+
+If the build completes successfully, the ESP binary built is at:
+
+    ./bazel-bin/src/nginx/main/nginx-esp
+
+# Runn ESP tests #
+
+libio-socket-ssl-perl is needed to run ESP tests: 
+
+    sudo apt-get install libio-socket-ssl-perl
+
+To run ESP tests, run the following command in the terminal.
+
+    bazel test //src/... //third_party:all

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -26,7 +26,12 @@ The ESP binary location is:
 
 # Running unit and integratino tests #
 
-    # Run ESP unit and integration tests
+libio-socket-ssl-perl is needed to run ESP tests: 
+
+    sudo apt-get install libio-socket-ssl-perl
+
+Run ESP unit and integration tests:
+
     bazel test //src/... //third_party:all
 
 # Running ASAN and TSAN tests #

--- a/doc/tutorial.md
+++ b/doc/tutorial.md
@@ -16,9 +16,16 @@ On Mac OS X, install:
 
 On Linux, install:
 
+    # Software packages needed for building ESP
     sudo apt-get install -y \
          g++ git openjdk-8-jdk openjdk-8-source \
          pkg-config unzip uuid-dev zip zlib1g-dev
+
+    # Software packages needed for building ESP
+    sudo apt-get install libtool m4 autotools-dev automake
+
+    # Software packages needed for running ESP tests
+    sudo apt-get install libio-socket-ssl-perl
 
 ## Bazel ##
 
@@ -37,7 +44,8 @@ script variable `BAZEL_VERSION=<SHA>`.
 # Building ESP #
 
 Clone the ESP [GitHub repository](https://github.com/cloudendpoints/esp),
-initialize Git submodules, and build ESP using Bazel:
+initialize Git submodules, and build ESP using Bazel. Detailed instructions
+for building ESP on Ubuntu 16.04 can be found in the [document](/doc/build-esp-on-ubuntu-16-04.md).
 
     # Clone the ESP repository
     git clone https://github.com/cloudendpoints/esp


### PR DESCRIPTION
1. Add the software packages required for building ESP.
2. Add the software packages required for running ESP tests.
3. Add a step-by-step guide for building ESP on Ubuntu 16.04, and running tests.