### PR TITLE
Retrieve and save ESP Nginx error log in the App Engine Flex environment

### DIFF
--- a/script/linux-gae-instance
+++ b/script/linux-gae-instance
@@ -143,6 +143,17 @@ function set_ssh_keys() {
   fi
 }
 
+
+function download_nginx_error_logs() {
+  local NGINX_ERROR_LOG_FILE="${LOG_DIRECTORY}/nginx_error.log"
+
+  gcloud config set project "${PROJECT}"
+  gcloud logging read "resource.labels.project_id=${PROJECT} AND \
+    resource.labels.version_id=${VERSION} AND \
+    logName=projects/${PROJECT}/logs/appengine.googleapis.com%2Fnginx.error" 2>&1 \
+    | tee "${NGINX_ERROR_LOG_FILE}"
+}
+
 function download_nginx_logs() {
   local vm_id vm_zone vm_name
 
@@ -204,7 +215,7 @@ function download_nginx_logs() {
 case "${COMMAND}" in
   create | deploy)  retry -n 5 -s 10 deploy_application;;
   delete         )  delete_application;;
-  nginx-logs     )  download_nginx_logs;;
+  nginx-logs     )  download_nginx_error_logs;;
   *              )  usage "Unknown command ${COMMAND}."
 esac
 

--- a/script/linux-test-vm-bookstore
+++ b/script/linux-test-vm-bookstore
@@ -265,8 +265,10 @@ if [[ -n "${BUCKET}" ]] ; then
     -t "${TEST_ID}" \
     -r "${GAE_VERSION}" \
     || error_exit "Could not create ${JSON_FILE}."
-
+  
   echo "Uploading logs to ${BUCKET}."
+  "${ROOT}/script/linux-gae-instance" \
+    -v "${GAE_VERSION}" -p "${PROJECT_ID}" -d "${LOG_DIRECTORY}" nginx-logs
   gsutil -h "Content-Type:text/plain" -m cp -r "${LOG_DIRECTORY}" "${BUCKET}/${GAE_VERSION}"
 fi
 

--- a/script/linux-test-vm-echo
+++ b/script/linux-test-vm-echo
@@ -144,6 +144,8 @@ if [[ -n "${BUCKET}" ]] ; then
     || error_exit "Could not create ${JSON_FILE}."
 
   echo "Uploading logs."
+  "${ROOT}/script/linux-gae-instance" \
+    -v "${GAE_VERSION}" -p "${PROJECT_ID}" -d "${LOG_DIRECTORY}" nginx-logs
   gsutil -h 'Content-Type:text/plain' -m cp -r "${LOG_DIRECTORY}" "${BUCKET}/${GAE_VERSION}"
 
 fi


### PR DESCRIPTION
1. Problem description
With current ESP Jenkins test scripts, ESP Nginx error log is not retrieved and saved when running in the App Engine Flex environment.

2. Solution
This code retrieves ESP Nginx error log and saves it to Cloud Storage when running ESP Jenkins tests in the App Engine Flex environment.
