### PR TITLE
Force to use the entrypoint

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -850,7 +850,7 @@ def DefaultNode(Closure body) {
       containerTemplate(
           name: 'debian-8',
           image: SLAVE_IMAGE,
-          command: 'cat',
+          args: 'cat',
           ttyEnabled: true,
           privileged: true,
           alwaysPullImage: false,
@@ -875,7 +875,7 @@ def BuildNode(Closure body) {
       containerTemplate(
           name: 'debian-8',
           image: SLAVE_IMAGE,
-          command: 'cat',
+          args: 'cat',
           ttyEnabled: true,
           privileged: true,
           alwaysPullImage: false,


### PR DESCRIPTION
command is overwriting the [entrypoint](https://github.com/cloudendpoints/esp/blob/master/jenkins/slaves/entrypoint) set in the docker image, which starts the docker daemon.