### PR TITLE
fix transcoding issue with h2

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -262,7 +262,7 @@ cc_library(
 def transcoding_repositories(bind=True):
     native.git_repository(
         name = "httpjson_transcoding",
-        commit = "dadab6a5a273db5fff5b2d964aff39f3fd0bee5b",
+        commit = "6c54b75dbd294e1e264e3f9476ffb52be8763cd3",
         remote = "https://github.com/grpc-ecosystem/grpc-httpjson-transcoding.git",
     )
 

--- a/src/grpc/zero_copy_stream.h
+++ b/src/grpc/zero_copy_stream.h
@@ -57,6 +57,7 @@ class GrpcZeroCopyInputStream
   bool Skip(int count) { return false; }                     // not supported
   ::google::protobuf::int64 ByteCount() const { return 0; }  // Not implemented
   int64_t BytesAvailable() const;
+  bool Finished() const { return finished_; }
 
  private:
   GrpcMessageSerializer serializer_;

--- a/src/nginx/t/BUILD
+++ b/src/nginx/t/BUILD
@@ -317,6 +317,7 @@ nginx_suite(
         "transcoding_bindings.t",
         "transcoding_deep_struct.t",
         "transcoding_errors.t",
+        "transcoding_h2.t",
         "transcoding_head.t",
         "transcoding_ignore_unknown_fields.t",
         "transcoding_large.t",

--- a/src/nginx/t/transcoding_h2.t
+++ b/src/nginx/t/transcoding_h2.t
@@ -1,0 +1,135 @@
+# Copyright (C) Extensible Service Proxy Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+################################################################################
+#
+use strict;
+use warnings;
+
+################################################################################
+
+use src::nginx::t::ApiManager;   # Must be first (sets up import path to the Nginx test module)
+use src::nginx::t::HttpServer;
+use src::nginx::t::ServiceControl;
+use Test::Nginx;  # Imports Nginx's test module
+use Test::Nginx::HTTP2;
+use Test::More;   # And the test framework
+use JSON::PP;
+
+################################################################################
+
+# Port assignments
+my $NginxPort = ApiManager::pick_port();
+my $ServiceControlPort = ApiManager::pick_port();
+my $GrpcServerPort = ApiManager::pick_port();
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(5);
+
+$t->write_file('service.pb.txt',
+  ApiManager::get_grpc_echo_test_service_config(
+    'endpoints-transcoding-test.cloudendpointsapis.com',
+    "http://127.0.0.1:${ServiceControlPort}"));
+
+$t->write_file_expand('nginx.conf', <<EOF);
+%%TEST_GLOBALS%%
+daemon off;
+events {
+  worker_connections 32;
+}
+http {
+  %%TEST_GLOBALS_HTTP%%
+  server_tokens off;
+  server {
+    listen 127.0.0.1:${NginxPort} http2;
+    server_name localhost;
+    location / {
+      endpoints {
+        api service.pb.txt;
+        on;
+      }
+      grpc_pass 127.0.0.1:${GrpcServerPort};
+    }
+  }
+}
+EOF
+
+$t->run_daemon(\&service_control, $t, $ServiceControlPort, 'servicecontrol.log');
+$t->run_daemon(\&ApiManager::grpc_test_server, $t, "127.0.0.1:${GrpcServerPort}");
+
+is($t->waitforsocket("127.0.0.1:${ServiceControlPort}"), 1, "Service control socket ready.");
+is($t->waitforsocket("127.0.0.1:${GrpcServerPort}"), 1, "GRPC test server socket ready.");
+$t->run();
+is($t->waitforsocket("127.0.0.1:${NginxPort}"), 1, "Nginx socket ready.");
+
+################################################################################
+
+my $request = ApiManager::get_large_report_request($t, "2000");
+my $content_length = length($request);
+
+my $s = Test::Nginx::HTTP2->new($NginxPort);
+my $sid = $s->new_stream({
+  headers => [
+    { name => ':method', value => 'POST', mode => 0 },
+    { name => ':scheme', value => 'http', mode => 0 },
+    { name => ':path', value => '/echoreport?key=api-key', mode => 1 },
+    { name => ':authority', value => 'localhost', mode => 1 },
+    { name => 'content-type', value => 'application/json', mode => 1 }
+  ],
+  body_more => 1 });
+$s->h2_body($request, { body_split => [1500], split => [1509]});
+my $frames = $s->read(all => [{ sid => $sid, fin => 1 }]);
+
+$t->stop_daemons();
+
+my ($frame) = grep { $_->{type} eq "HEADERS" } @$frames;
+is($frame->{headers}->{':status'}, 200, 'response ok');
+
+my @response_frames = grep { $_->{type} eq "DATA" } @$frames;
+my $response = join('', map { $_->{data} } @response_frames);
+ok(ApiManager::compare_json($response, decode_json($request)), "Large response is echoed.");
+
+################################################################################
+
+sub service_control {
+  my ($t, $port, $file) = @_;
+
+  my $server = HttpServer->new($port, $t->testdir() . '/' . $file)
+    or die "Can't create test server socket: $!\n";
+
+  local $SIG{PIPE} = 'IGNORE';
+
+  $server->on_sub('POST', '/v1/services/endpoints-transcoding-test.cloudendpointsapis.com:check', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<EOF;
+HTTP/1.1 200 OK
+Content-Type: application/json
+Connection: close
+
+EOF
+  });
+
+  $server->run();
+}
+
+################################################################################

--- a/src/nginx/zero_copy_stream.h
+++ b/src/nginx/zero_copy_stream.h
@@ -76,9 +76,6 @@ class NgxRequestZeroCopyInputStream
   // file-based)
   ngx_buf_t* buf_;
 
-  // The current position in the buffer
-  u_char* pos_;
-
   utils::Status status_;
 };
 


### PR DESCRIPTION
- remove `pos_` from NgxRequestZeroCopyInputStream

NGINX may parse additional DATA frame into the existing `ngx_buf_t` which `NgxRequestZeroCopyInputStream` is holding, makes `pos_` is in the wrong place in the middle of buffer.