### PR TITLE
scale nginx workers to number of cores

### DIFF
--- a/docker/custom/nginx.conf.template
+++ b/docker/custom/nginx.conf.template
@@ -2,7 +2,7 @@ daemon off;
 
 user nginx nginx;
 
-worker_processes 1;
+worker_processes auto;
 
 error_log  /var/log/nginx/error.log error;
 


### PR DESCRIPTION
Nginx doesn't use worker threads, meaning with the current configuration, the esp can only ever take advantage of one cpu core, which can become a bottleneck especially if TLS in involved. The nginx docs http://nginx.org/en/docs/ngx_core_module.html#worker_processes even recommend `auto` as a good place to start.

```
$ ps axH |grep nginx
 1926 ?        Ss     0:00 nginx: master process nginx -p /usr -c /etc/nginx/endpoints/nginx.conf
 1949 ?        S     66:42 nginx: worker process
```