### PR TITLE
Allow underscores in headers

### DIFF
--- a/src/nginx/conf/nginx.conf
+++ b/src/nginx/conf/nginx.conf
@@ -5,6 +5,7 @@ events {
 http {
     server {
         error_log logs/error.log debug;
+        underscores_in_headers on;
         listen       8080;
         location / {
             index  index.html index.htm;


### PR DESCRIPTION
Fixes: #323

If you do not explicitly set `underscores_in_headers on;`, nginx will silently drop HTTP headers with underscores (which are perfectly valid according to the HTTP standard). 

This is done in order to prevent ambiguities when mapping headers to CGI variables, as both dashes and underscores are mapped to underscores during that process.