### PR TITLE
Skip the host header in the grpc metadata

### DIFF
--- a/src/grpc/proxy_flow.cc
+++ b/src/grpc/proxy_flow.cc
@@ -35,9 +35,9 @@ extern "C" {
 #include "src/core/lib/slice/b64.h"
 }
 
+using ::google::api_manager::utils::Status;
 using ::google::protobuf::util::error::UNAVAILABLE;
 using ::google::protobuf::util::error::UNKNOWN;
-using ::google::api_manager::utils::Status;
 using std::chrono::system_clock;
 
 namespace google {
@@ -131,6 +131,7 @@ namespace {
 
 const char kGrpcEncoding[] = "grpc-encoding";
 const char kGrpcAcceptEncoding[] = "grpc-accept-encoding";
+const char kGrpcHostHeader[] = "host";
 
 Status ProcessDownstreamHeaders(
     const std::multimap<std::string, std::string> &headers,
@@ -138,7 +139,10 @@ Status ProcessDownstreamHeaders(
   static grpc_exec_ctx exec_ctx = GRPC_EXEC_CTX_INIT;
 
   for (const auto &it : headers) {
-    if (it.first == kGrpcEncoding || it.first == kGrpcAcceptEncoding) {
+    // gRPC requests (HTTP2) with a host header will lead some gRPC servers to
+    // reject it, so the host header is skipped here.
+    if (it.first == kGrpcEncoding || it.first == kGrpcAcceptEncoding ||
+        it.first == kGrpcHostHeader) {
       // GRPC lib will add this header, so not adding it to client_context_
       continue;
     }

--- a/src/nginx/t/BUILD
+++ b/src/nginx/t/BUILD
@@ -54,8 +54,8 @@ nginx_suite(
         "auth_ok_check_fail.t",
         "auth_pass_user_info.t",
         "auth_pkey_cache.t",
-        "auth_remove_user_info.t",
         "auth_redirect.t",
+        "auth_remove_user_info.t",
         "auth_unreachable_pkey.t",
         "new_http.t",
         "service_control_disabled.t",
@@ -321,12 +321,13 @@ nginx_suite(
         "transcoding_h2.t",
         "transcoding_head.t",
         "transcoding_ignore_unknown_fields.t",
+        "grpc_skip_host_header_in_metadata.t",
         "transcoding_large.t",
         "transcoding_metadata.t",
         "transcoding_query_params.t",
         #Temporarily disable the transcoding_shared_port_ssl.t test,
         #which occasionally fails in the Jenkins presubmit tests.
-        #To-do: enable the transcoding_shared_port_ssl.t test after 
+        #To-do: enable the transcoding_shared_port_ssl.t test after
         #the Jenkins problem is resolved.
         #"transcoding_shared_port_ssl.t",
         "transcoding_status.t",

--- a/src/nginx/t/grpc_skip_host_header_in_metadata.t
+++ b/src/nginx/t/grpc_skip_host_header_in_metadata.t
@@ -1,0 +1,147 @@
+# Copyright (C) Extensible Service Proxy Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+################################################################################
+#
+use strict;
+use warnings;
+################################################################################
+
+use src::nginx::t::ApiManager;   # Must be first (sets up import path to the Nginx test module)
+use src::nginx::t::HttpServer;
+use Test::Nginx;  # Imports Nginx's test module
+use Test::More;   # And the test framework
+
+################################################################################
+# Port assignments
+my $NginxPort = ApiManager::pick_port();
+my $ServiceControlPort = ApiManager::pick_port();
+my $GrpcServerPort = ApiManager::pick_port();
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(6);
+
+$t->write_file('service.pb.txt',
+  ApiManager::get_transcoding_test_service_config(
+    'endpoints-transcoding-test.cloudendpointsapis.com',
+    "http://127.0.0.1:${ServiceControlPort}"));
+
+$t->write_file_expand('nginx.conf', <<EOF);
+%%TEST_GLOBALS%%
+daemon off;
+events {
+  worker_connections 32;
+}
+http {
+  %%TEST_GLOBALS_HTTP%%
+  server_tokens off;
+  server {
+    listen 127.0.0.1:${NginxPort};
+    server_name localhost;
+    location / {
+      endpoints {
+        api service.pb.txt;
+        on;
+      }
+      grpc_pass 127.0.0.1:${GrpcServerPort};
+    }
+  }
+}
+EOF
+
+$t->run_daemon(\&service_control, $t, $ServiceControlPort, 'servicecontrol.log');
+ApiManager::run_transcoding_test_server($t, 'backend.log', "127.0.0.1:${GrpcServerPort}", '--printmetadata');
+
+is($t->waitforsocket("127.0.0.1:${ServiceControlPort}"), 1, "Service control socket ready.");
+is($t->waitforsocket("127.0.0.1:${GrpcServerPort}"), 1, "GRPC test backend socket ready.");
+$t->run();
+is($t->waitforsocket("127.0.0.1:${NginxPort}"), 1, "Nginx socket ready.");
+
+################################################################################
+
+my $request = <<'EOF';
+{
+  "id" : 100,
+  "theme" : "Classics",
+  "unknown1" : "a",
+  "unknown2" : { "a" : "b" },
+  "unknown3" : [ "a", "b", "c" ]
+}
+EOF
+my $request_size = length($request);
+
+my $response = ApiManager::http($NginxPort,<<EOF);
+POST /shelves?key=api-key HTTP/1.0
+Host: 127.0.0.1:${NginxPort}
+Content-Type: application/json
+Content-Length: $request_size
+
+$request
+EOF
+
+ok(ApiManager::verify_http_json_response($response,
+    {'id'=>'100', 'theme' => 'Classics'}), "The shelf was created successfully.");
+
+$t->stop_daemons();
+
+# Verify the translated request
+my $backend_output = $t->read_file('backend.log');
+my @backend_requests = split /\r\n\r\n/, $backend_output;
+
+# Verify that the host header is skipped in the metadata
+unlike($backend_output, qr(metadata_key:host));
+
+ok(ApiManager::compare_json($backend_requests[0],
+    {'shelf' => {'id'=>'100', 'theme' => 'Classics'}}),
+  "The translated request doesnt have the unknown fields");
+
+################################################################################
+
+sub service_control {
+  my ($t, $port, $file) = @_;
+  my $server = HttpServer->new($port, $t->testdir() . '/' . $file)
+    or die "Can't create test server socket: $!\n";
+
+  $server->on_sub('POST', '/v1/services/endpoints-transcoding-test.cloudendpointsapis.com:check', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<EOF;
+HTTP/1.1 200 OK
+Content-Type: application/json
+Connection: close
+
+EOF
+  });
+
+  $server->on_sub('POST', '/v1/services/endpoints-transcoding-test.cloudendpointsapis.com:report', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<EOF;
+HTTP/1.1 200 OK
+Content-Type: application/json
+Connection: close
+
+EOF
+  });
+
+  $server->run();
+}
+

--- a/test/transcoding/bookstore-server.cc
+++ b/test/transcoding/bookstore-server.cc
@@ -73,6 +73,20 @@ void PrintRequest(const MessageType& message) {
   std::cout.flush();
 }
 
+// Prints the client metadata to STDOUT
+void PrintClientMetadata(const ::grpc::ServerContext& cxt) {
+  static std::mutex mutex;
+  std::lock_guard<std::mutex> lock(mutex);
+
+  static const char delimiter[] = "\r\n\r\n";
+  for (auto it : cxt.client_metadata()) {
+    std::cout << "metadata_key:" << it.first << std::endl;
+    std::cout << "metadata_value:" << it.second << std::endl;
+  }
+  std::cout << delimiter;
+  std::cout.flush();
+}
+
 // Helper to generate names for books & shelves
 template <typename T>
 int IdGenerator() {
@@ -83,7 +97,8 @@ int IdGenerator() {
 // A memory based Bookstore Service
 class BookstoreServiceImpl : public Bookstore::Service {
  public:
-  BookstoreServiceImpl() {
+  BookstoreServiceImpl(bool printmetadata) {
+    printmetadata_ = printmetadata;
     // Create sample shelves
     shelves_.emplace_back(CreateShelfObject("Fiction"));
     shelves_.emplace_back(CreateShelfObject("Fantasy"));
@@ -99,11 +114,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
 
   // Bookstore::Service implementation
 
-  ::grpc::Status ListShelves(::grpc::ServerContext*,
+  ::grpc::Status ListShelves(::grpc::ServerContext* ctx,
                              const ::google::protobuf::Empty* request,
                              ListShelvesResponse* reply) {
     std::cerr << "GRPC-BACKEND: ListShelves" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     for (const auto& shelf : shelves_) {
       *reply->add_shelves() = shelf;
@@ -111,10 +129,13 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status::OK;
   }
 
-  ::grpc::Status CreateShelf(::grpc::ServerContext*,
+  ::grpc::Status CreateShelf(::grpc::ServerContext* ctx,
                              const CreateShelfRequest* request, Shelf* reply) {
     std::cerr << "GRPC-BACKEND: CreateShelf" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto shelf = request->shelf();
     if (0 == shelf.id()) {
@@ -145,10 +166,13 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status::OK;
   }
 
-  ::grpc::Status GetShelf(::grpc::ServerContext*,
+  ::grpc::Status GetShelf(::grpc::ServerContext* ctx,
                           const GetShelfRequest* request, Shelf* reply) {
     std::cerr << "GRPC-BACKEND: GetShelf" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     int id = request->shelf();
     for (const auto& shelf : shelves_) {
@@ -169,11 +193,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
                           std::string(detail_status_bin));
   }
 
-  ::grpc::Status DeleteShelf(::grpc::ServerContext*,
+  ::grpc::Status DeleteShelf(::grpc::ServerContext* ctx,
                              const DeleteShelfRequest* request,
                              ::google::protobuf::Empty* reply) {
     std::cerr << "GRPC-BACKEND: DeleteShelf" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto id = request->shelf();
     auto it =
@@ -189,11 +216,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
     }
   }
 
-  ::grpc::Status ListBooks(::grpc::ServerContext*,
+  ::grpc::Status ListBooks(::grpc::ServerContext* ctx,
                            const ListBooksRequest* request,
                            ListBooksResponse* reply) {
     std::cerr << "GRPC-BACKEND: ListBooks" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto shelf_id = request->shelf();
     if (!ShelfExists(shelf_id)) {
@@ -208,10 +238,13 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status::OK;
   }
 
-  ::grpc::Status CreateBook(::grpc::ServerContext*,
+  ::grpc::Status CreateBook(::grpc::ServerContext* ctx,
                             const CreateBookRequest* request, Book* reply) {
     std::cerr << "GRPC-BACKEND: CreateBook" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto shelf_id = request->shelf();
     if (!ShelfExists(shelf_id)) {
@@ -229,10 +262,13 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status::OK;
   }
 
-  ::grpc::Status GetBook(::grpc::ServerContext*, const GetBookRequest* request,
-                         Book* reply) {
+  ::grpc::Status GetBook(::grpc::ServerContext* ctx,
+                         const GetBookRequest* request, Book* reply) {
     std::cerr << "GRPC-BACKEND: GetBook" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto shelf_id = request->shelf();
     if (!ShelfExists(shelf_id)) {
@@ -250,11 +286,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status(grpc::NOT_FOUND, "Book not found");
   }
 
-  ::grpc::Status DeleteBook(::grpc::ServerContext*,
+  ::grpc::Status DeleteBook(::grpc::ServerContext* ctx,
                             const DeleteBookRequest* request,
                             ::google::protobuf::Empty* reply) {
     std::cerr << "GRPC-BACKEND: DeleteBook" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto shelf_id = request->shelf();
     if (!ShelfExists(shelf_id)) {
@@ -272,11 +311,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status(grpc::NOT_FOUND, "Book not found");
   }
 
-  ::grpc::Status QueryShelves(::grpc::ServerContext*,
+  ::grpc::Status QueryShelves(::grpc::ServerContext* ctx,
                               const QueryShelvesRequest* request,
                               ListShelvesResponse* reply) {
     std::cerr << "GRPC-BACKEND: QueryShelves" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     for (const auto& shelf : shelves_) {
       if (request->shelf().id() != 0 && shelf.id() != request->shelf().id()) {
@@ -291,11 +333,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status::OK;
   }
 
-  ::grpc::Status QueryBooks(::grpc::ServerContext*,
+  ::grpc::Status QueryBooks(::grpc::ServerContext* ctx,
                             const QueryBooksRequest* request,
                             ListBooksResponse* reply) {
     std::cerr << "GRPC-BACKEND: QueryBooks" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     auto begin = std::begin(books_);
     auto end = std::end(books_);
@@ -324,11 +369,14 @@ class BookstoreServiceImpl : public Bookstore::Service {
     return ::grpc::Status::OK;
   }
 
-  ::grpc::Status EchoStruct(::grpc::ServerContext*,
+  ::grpc::Status EchoStruct(::grpc::ServerContext* ctx,
                             const ::google::protobuf::Struct* request,
                             ::google::protobuf::Struct* reply) {
     std::cerr << "GRPC-BACKEND: EchoStruct" << std::endl;
     PrintRequest(*request);
+    if (printmetadata_) {
+      PrintClientMetadata(*ctx);
+    }
 
     *reply = *request;
 
@@ -360,6 +408,9 @@ class BookstoreServiceImpl : public Bookstore::Service {
                         }) != std::end(shelves_);
   }
 
+  // Whether print metadata
+  bool printmetadata_;
+
   // The database of shelves and books
   std::vector<Shelf> shelves_;
   std::multimap<int, Book> books_;
@@ -371,9 +422,11 @@ class BookstoreServiceImpl : public Bookstore::Service {
 
 int main(int argc, char** argv) {
   auto address = argc > 1 ? argv[1] : "localhost:8081";
+  bool printmetadata =
+      (argc > 2 && !std::string("--printmetadata").compare(argv[2]));
 
   // Bring up the server at the specified address.
-  ::endpoints::examples::bookstore::BookstoreServiceImpl service;
+  ::endpoints::examples::bookstore::BookstoreServiceImpl service(printmetadata);
   ::grpc::ServerBuilder builder;
   builder.AddListeningPort(address, ::grpc::InsecureServerCredentials());
   builder.RegisterService(&service);


### PR DESCRIPTION
gRPC requests (HTTP2) with a host header will lead some gRPC servers to reject it, so the host header is skipped in the grpc metadata.