### PR TITLE
Update Debian 8 to 9 for GCE tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ SUPPORTED_STAGES = [
 ]
 
 // Supported VM Images
-DEBIAN_JESSIE = 'debian-8'
+DEBIAN_STRETCH = 'debian-9'
 SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-8:0.7'
 
 // Release Qualification end to end tests.
@@ -269,12 +269,12 @@ def e2eTest() {
   def branches = [
       ['gce-debian-8', {
         DefaultNode {
-          e2eGCE(DEBIAN_JESSIE, 'fixed')
+          e2eGCE(DEBIAN_STRETCH, 'fixed')
         }
       }],
       ['gce-debian-8-managed', {
         DefaultNode {
-          e2eGCE(DEBIAN_JESSIE, 'managed')
+          e2eGCE(DEBIAN_STRETCH, 'managed')
         }
       }],
       ['gke-tight-http', {

--- a/script/jenkins-utilities
+++ b/script/jenkins-utilities
@@ -430,6 +430,6 @@ function e2e_usage() {
   -s <skip cleanup>
   -t <test type: http, https, custom>
   -V <endpoints-runtime version>
-  -v <vm image to use. Supported are [debian-8]>"
+  -v <vm image to use. Supported are [debian-9]>"
   exit 1
 }

--- a/test/bookstore/gce/vm_startup_script_template.sh
+++ b/test/bookstore/gce/vm_startup_script_template.sh
@@ -65,7 +65,7 @@ function run() {
 }
 
 # Check installed version and compare it to expected version
-function check_esp_version_debian_8() {
+function check_esp_version_debian_9() {
   local version=''
   version=$(dpkg -l | grep endpoints-runtime | awk '{print $3}')
   [[ "${version}" == "${ESP_VERSION}" ]] || \
@@ -80,8 +80,8 @@ function clean_apt() {
   # if failures are related to esp, apt-get install will fail.
   apt-get update --fix-missing
 }
-# Install Debian 8 packages
-function install_pkg_debian8() {
+# Install Debian 9 packages
+function install_pkg_debian9() {
   clean_apt
   # Install dependencies.
   # TODO: delete python dependencies once new package is released.
@@ -90,8 +90,8 @@ function install_pkg_debian8() {
   return 1
 }
 
-# Install ESP and Bookstore for Debian 8
-function install_debian_8() {
+# Install ESP and Bookstore for Debian 9
+function install_debian_9() {
   if [[ -z "${DIRECT_REPO}" && -n "${TESTING_REMOTE_DEB}" ]]; then
     # Installing the testing debian package with dpkg
     TESTING_LOCAL_DEB="enpoints-runtime.deb"
@@ -113,18 +113,18 @@ function install_debian_8() {
       | tee /etc/apt/sources.list.d/google-cloud-endpoints.list
     curl --silent https://packages.cloud.google.com/apt/doc/apt-key.gpg \
       | apt-key add -
-    run retry install_pkg_debian8 endpoints-runtime
+    run retry install_pkg_debian9 endpoints-runtime
   fi
   if [[ -n "${TESTING_REMOTE_DEB}" && -n "${DIRECT_REPO}" ]]; then
     # Cannot check version with official repo.
-    check_esp_version_debian_8
+    check_esp_version_debian_9
   fi
 }
 
 case "${VM_IMAGE}" in
-  "debian-8")
-    install_debian_8
-    run retry install_pkg_debian8 npm supervisor
+  "debian-9")
+    install_debian_9
+    run retry install_pkg_debian9 npm supervisor
     ;;
   *) echo "${VM_IMAGE} is not yet supported" && exit 1;;
 esac

--- a/test/bookstore/gce/vm_startup_script_template.sh
+++ b/test/bookstore/gce/vm_startup_script_template.sh
@@ -92,11 +92,11 @@ function install_pkg_debian9() {
 }
 
 function install_npm_debian9() {
-  run retry install_pkg_debian9 curl
+  install_pkg_debian9 curl
 
   curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
 
-  run retry install_pkg_debian9 nodejs
+  install_pkg_debian9 nodejs
 }
 
 # Install ESP and Bookstore for Debian 9
@@ -134,7 +134,7 @@ case "${VM_IMAGE}" in
   "debian-9")
     install_debian_9
     run retry install_pkg_debian9 supervisor
-    install_npm_debian9
+    run retry install_npm_debian9
     ;;
   *) echo "${VM_IMAGE} is not yet supported" && exit 1;;
 esac

--- a/test/bookstore/gce/vm_startup_script_template.sh
+++ b/test/bookstore/gce/vm_startup_script_template.sh
@@ -80,6 +80,7 @@ function clean_apt() {
   # if failures are related to esp, apt-get install will fail.
   apt-get update --fix-missing
 }
+
 # Install Debian 9 packages
 function install_pkg_debian9() {
   clean_apt

--- a/test/bookstore/gce/vm_startup_script_template.sh
+++ b/test/bookstore/gce/vm_startup_script_template.sh
@@ -91,6 +91,14 @@ function install_pkg_debian9() {
   return 1
 }
 
+function install_npm_debian9() {
+  run retry install_pkg_debian9 curl
+
+  curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
+
+  run retry install_pkg_debian9 nodejs
+}
+
 # Install ESP and Bookstore for Debian 9
 function install_debian_9() {
   if [[ -z "${DIRECT_REPO}" && -n "${TESTING_REMOTE_DEB}" ]]; then
@@ -125,7 +133,8 @@ function install_debian_9() {
 case "${VM_IMAGE}" in
   "debian-9")
     install_debian_9
-    run retry install_pkg_debian9 npm supervisor
+    run retry install_pkg_debian9 supervisor
+    install_npm_debian9
     ;;
   *) echo "${VM_IMAGE} is not yet supported" && exit 1;;
 esac


### PR DESCRIPTION
GCE has started to use Debian 9 images instead of Debian 8. Adjust our test setup to avoid errors.