### PR TITLE
CORS always adds the Access-Control-Allow-Origin header

### DIFF
--- a/start_esp/nginx-auto.conf.template
+++ b/start_esp/nginx-auto.conf.template
@@ -171,7 +171,7 @@ http {
     }
 
     if ($cors = "true") {
-        add_header 'Access-Control-Allow-Origin' "$allow_origin";
+        add_header 'Access-Control-Allow-Origin' "$allow_origin" always;
         add_header 'Access-Control-Allow-Methods' '${cors_allow_methods}' always;
         add_header 'Access-Control-Allow-Headers' '${cors_allow_headers}' always;
         add_header 'Access-Control-Expose-Headers' '${cors_expose_headers}' always;


### PR DESCRIPTION
Per http://nginx.org/en/docs/http/ngx_http_headers_module.html, add_header "adds the specified field to a response header provided that the response code equals 200, 201 (1.3.10), 204, 206, 301, 302, 303, 304, 307 (1.1.16, 1.0.13), or 308 (1.13.0)."  This PR always adds the Access-Control-Allow-Origin header regardless of the response code.