### PR TITLE
Feature: TLS for gRPC

### DIFF
--- a/src/nginx/grpc.h
+++ b/src/nginx/grpc.h
@@ -38,6 +38,18 @@ namespace google {
 namespace api_manager {
 namespace nginx {
 
+// Configures a set of TLS root authorities.
+char *ConfigureGrpcAuthorities(ngx_conf_t *ct, ngx_command_t *cmd,
+                               void *conf);
+
+// Configures a client-side TLS key for gRPC.
+char *ConfigureGrpcClientKey(ngx_conf_t *ct, ngx_command_t *cmd,
+                             void *conf);
+
+// Configures a client-side TLS cert for gRPC.
+char *ConfigureGrpcClientCertificate(ngx_conf_t *ct, ngx_command_t *cmd,
+                                     void *conf);
+
 // Configures a location to use the GRPC-aware proxy backend handler.
 char *ConfigureGrpcBackendHandler(ngx_conf_t *ct, ngx_command_t *cmd,
                                   void *conf);

--- a/src/nginx/module.cc
+++ b/src/nginx/module.cc
@@ -234,12 +234,60 @@ ngx_command_t ngx_esp_commands[] = {
         //
         // Usage:
         //   location / {
+        //     [grpc_roots /path/to/roots.pem;]
+        //     [grpc_client_key /path/to/client/key.pem;]
+        //     [grpc_client_certificate /path/to/client/cert.pem;]
         //     grpc_pass [<backend_address> [override]];
         //   }
         //
         ngx_string("grpc_pass"),
         NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS | NGX_CONF_TAKE12,
         ConfigureGrpcBackendHandler, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr,
+    },
+    {
+        // grpc_roots sets up TLS certification authorities, to validate
+        // the certificate sent back by a gRPC backend. If left unspecified,
+        // the default set of nginx roots are used. The special value
+        // "default" can be specified to install the default authorities from
+        // gRPC core (this is the default behavior if no directive is
+        // specified).
+        //
+        // Usage:
+        //   location / {
+        //     grpc_roots [/path/to/roots.pem|"default"];
+        //   }
+        //
+        ngx_string("grpc_roots"),
+        NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+        ConfigureGrpcAuthorities, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr,
+    },
+    {
+        // grpc_client_key sets up a TLS client key to be used when
+        // communicating with a gRPC backend. it is expected that the user
+        // also specify `grpc_client_certificate`.
+        //
+        // Usage:
+        //   location / {
+        //     grpc_client_key /path/to/key.pem;
+        //   }
+        //
+        ngx_string("grpc_client_key"),
+        NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+        ConfigureGrpcClientKey, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr,
+    },
+    {
+        // grpc_client_certificate sets up a TLS client key to be used
+        // when communicating with a gRPC backend. it is expected that the
+        // user also specify `grpc_client_key`.
+        //
+        // Usage:
+        //   location / {
+        //     grpc_client_certificate /path/to/cert.pem;
+        //   }
+        //
+        ngx_string("grpc_client_certificate"),
+        NGX_HTTP_LOC_CONF | NGX_CONF_TAKE1,
+        ConfigureGrpcClientCertificate, NGX_HTTP_LOC_CONF_OFFSET, 0, nullptr,
     },
     {
         ngx_string("endpoints_status"), NGX_HTTP_LOC_CONF | NGX_CONF_NOARGS,
@@ -378,6 +426,9 @@ void *ngx_esp_create_loc_conf(ngx_conf_t *cf) {
 
   ngx_str_null(&lc->grpc_backend_address_override);
   ngx_str_null(&lc->grpc_backend_address_fallback);
+  ngx_str_null(&lc->grpc_backend_tls_roots);
+  ngx_str_null(&lc->grpc_backend_tls_client_key);
+  ngx_str_null(&lc->grpc_backend_tls_client_cert);
   ngx_str_null(&lc->metadata_server_url);
   ngx_str_null(&lc->service_controller_url);
   ngx_str_null(&lc->cloud_trace_api_url);

--- a/src/nginx/module.h
+++ b/src/nginx/module.h
@@ -172,6 +172,24 @@ typedef struct {
   // configured backend address for the API method in the API service
   // configuration.
   ngx_str_t grpc_backend_address_fallback;
+
+  // The GRPC TLS authority roots to use when authenticating the cert
+  // presented by a TLS-enabled GRPC backend. Should point to a file
+  // containing PEM certificate files to consider valid authorities.
+  // The special value `default` may be specified to use the gRPC
+  // library defaults.
+  ngx_str_t grpc_backend_tls_roots;
+
+  // The GRPC TLS client-side key to use when authenticating as the
+  // client-side of a mutual-TLS-enabled GRPC backend. Should point to
+  // a file containing a valid private key encoded in PEM.
+  ngx_str_t grpc_backend_tls_client_key;
+
+  // The GRPC TLS client-side certificate to use when authenticating
+  // as the client-side of a mutual-TLS-enabled GRPC backend. Should
+  // point to a file containing a valid certificate issued to the
+  // private key configured via `grpc_client_key`.
+  ngx_str_t grpc_backend_tls_client_cert;
 } ngx_esp_loc_conf_t;
 
 // **************************************************

--- a/src/nginx/util.h
+++ b/src/nginx/util.h
@@ -65,6 +65,11 @@ inline bool ngx_string_equal(const ngx_str_t &str1, const ngx_str_t &str2) {
   return str1.len == str2.len && !ngx_strncmp(str1.data, str2.data, str1.len);
 }
 
+// Check an ngx_str_t against a prefix ngx_str_t
+inline bool ngx_string_startswith(const ngx_str_t &subject, const ngx_str_t &prefix) {
+  return subject.len > prefix.len && ngx_strstr(subject.data, prefix.data) == 0;
+}
+
 // Log a message with a specific log level.
 void ngx_esp_log(ngx_log_t *log, ngx_uint_t level, ngx_str_t msg);
 


### PR DESCRIPTION
This changeset fixes and closes cloudendpoints/esp#346, by adding the ability to invoke the gRPC channel constructor with SSL/TLS credentials based on nginx config. I am of course completely open to feedback both on my approach and implementation, especially because C++ is not my native language

Basically, a few config entries are added, which are interpreted at startup and then passed to the gRPC `SslCredentials` struct:

**New config file entries**:
- `grpc_roots`: Specify a file full of PEMs to use as authorities, when operating from the client's perspective (so, authorities for upstream gRPC backends).

- `grpc_client_key`: Kind of obvious. Lets you specify a PEM file to load and use as a client-side private key.

- `grpc_client_certificte`: Matches the `grpc_client_key` with a path to a PEM file containing a client-side certificate.

**Behavior:**
To enable TLS upstream to gRPC, simply prefix the `grpc_pass` address with `grpcs://`, like so:
```
location / {
  grpc_pass grpcs://127.0.0.1:1337 override;
}
```

In that same block, specify other directives to control how TLS works. Here is a full configuration:
```
location / {
  grpc_pass grpcs://127.0.0.1:1337 override;
  grpc_client_key /path/to/client/key.pem;
  grpc_client_certificate /path/to/client/cert.pem;
  grpc_roots /path/to/custom/roots.pem
}
```

If either `grpc_client_key` or `grpc_client_certificate` is specified, the other must be specified. Both are loaded and kept for when the gRPC channel is initialized.

If `grpc_roots` is 1) left unspecified, or 2) specified with the special value `default`, the default root authorities from gRPC are used.

Remaining items to do:
- [ ] Fail if a client cert, but not a key, is specified
- [ ] Probably some unit tests somewhere
- [ ] Testing in sandbox with our own services
- [ ] Eagerly validate the key and cert (don't wait until channel initialization to fail)