### PR TITLE
Not to log access token

### DIFF
--- a/start_esp/fetch_service_config.py
+++ b/start_esp/fetch_service_config.py
@@ -138,7 +138,7 @@ def fetch_metadata_attributes(metadata):
           if key == "kube_env":
             value = "KUBE_ENV"
           out_str += "  {}: \"{}\"".format(key, value) + "\n"
-        logging.info("Attribute {}: {}".format(key, value))
+          logging.info("Attribute {}: {}".format(key, value))
     return out_str
 
 def make_access_token(secret_token_json):


### PR DESCRIPTION
start_esp is fetching many metadata fields.  their values are logged.   It includes access_token.  This could be a security risk since the log is piped and stored in many other places.

Not to log access_token
