### PR TITLE
Not checking service management rollouts if not traffic

### DIFF
--- a/src/api_manager/BUILD
+++ b/src/api_manager/BUILD
@@ -184,6 +184,7 @@ cc_test(
     size = "small",
     srcs = [
         "api_manager_test.cc",
+        "mock_request.h",
     ],
     data = glob(["testdata/*.json"]),
     linkstatic = 1,

--- a/src/api_manager/api_manager_impl.cc
+++ b/src/api_manager/api_manager_impl.cc
@@ -309,6 +309,9 @@ bool ApiManagerImpl::ReWriteURL(const char *uri, const size_t uri_len,
 
 std::unique_ptr<RequestHandlerInterface> ApiManagerImpl::CreateRequestHandler(
     std::unique_ptr<Request> request_data) {
+  if (config_manager_) {
+    config_manager_->CountRequests(1);
+  }
   return std::unique_ptr<RequestHandlerInterface>(new RequestHandler(
       check_workflow_, SelectService(), std::move(request_data)));
 }

--- a/src/api_manager/config_manager.h
+++ b/src/api_manager/config_manager.h
@@ -17,6 +17,7 @@
 
 #include "src/api_manager/context/global_context.h"
 #include "src/api_manager/service_management_fetch.h"
+#include "src/api_manager/utils/time_based_counter.h"
 
 namespace google {
 namespace api_manager {
@@ -81,6 +82,14 @@ class ConfigManager {
     current_rollout_id_ = rollout_id;
   }
 
+  // Count the requests to dynamically disable calling service_management
+  // if there is not any active requests within the last window.
+  void CountRequests(int n) {
+    if (window_request_counter_) {
+      window_request_counter_->Inc(n, std::chrono::system_clock::now());
+    }
+  }
+
  private:
   // Fetch the latest rollouts
   void FetchRollouts();
@@ -104,6 +113,8 @@ class ConfigManager {
   std::unique_ptr<PeriodicTimer> rollouts_refresh_timer_;
   // Previous rollouts id
   std::string current_rollout_id_;
+  // Time based window request counter
+  std::unique_ptr<utils::TimeBasedCounter> window_request_counter_;
 };
 
 }  // namespace api_manager

--- a/src/api_manager/config_manager_test.cc
+++ b/src/api_manager/config_manager_test.cc
@@ -244,6 +244,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutSingleServiceConfig) {
 
   config_manager->Init();
   ASSERT_EQ(0, sequence);
+  config_manager->CountRequests(1);
   raw_env_->RunTimer();
   ASSERT_EQ(1, sequence);
 }
@@ -276,6 +277,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
 
   config_manager->Init();
   ASSERT_EQ(0, sequence);
+  config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // callback should not be called
   ASSERT_EQ(0, sequence);
@@ -327,6 +329,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutMultipleServiceConfig) {
 
   config_manager->Init();
   ASSERT_EQ(0, sequence);
+  config_manager->CountRequests(1);
   raw_env_->RunTimer();
   ASSERT_EQ(1, sequence);
 }
@@ -395,6 +398,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
 
   config_manager->Init();
   ASSERT_EQ(0, sequence);
+  config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // One of ServiceConfig download was failed. The callback should not be
   // invoked
@@ -456,6 +460,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutSingleServiceConfigUpdate) {
   config_manager->Init();
   // run first periodic timer
   ASSERT_EQ(0, sequence);
+  config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // run second periodic timer
   ASSERT_EQ(1, sequence);
@@ -504,6 +509,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
   config_manager->Init();
   // run first periodic timer
   ASSERT_EQ(0, sequence);
+  config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // run second periodic timer
   ASSERT_EQ(1, sequence);

--- a/src/api_manager/utils/BUILD
+++ b/src/api_manager/utils/BUILD
@@ -23,12 +23,14 @@ cc_library(
     srcs = [
         "marshalling.cc",
         "status.cc",
+        "time_based_counter.cc",
         "url_util.cc",
         "version.cc",
     ],
     hdrs = [
         "marshalling.h",
         "stl_util.h",
+        "time_based_counter.h",
         "url_util.h",
     ],
     linkopts = select({
@@ -77,6 +79,19 @@ cc_test(
     size = "small",
     srcs = [
         "url_util_test.cc",
+    ],
+    linkstatic = 1,
+    deps = [
+        ":utils",
+        "//external:googletest_main",
+    ],
+)
+
+cc_test(
+    name = "time_based_counter_test",
+    size = "small",
+    srcs = [
+        "time_based_counter_test.cc",
     ],
     linkstatic = 1,
     deps = [

--- a/src/api_manager/utils/time_based_counter.cc
+++ b/src/api_manager/utils/time_based_counter.cc
@@ -1,0 +1,70 @@
+// Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "src/api_manager/utils/time_based_counter.h"
+
+using namespace std::chrono;
+
+namespace google {
+namespace api_manager {
+namespace utils {
+
+TimeBasedCounter::TimeBasedCounter(int window_size, milliseconds duration,
+                                   Tick t)
+    : slots_(window_size),
+      slot_duration_(duration / window_size),
+      count_(0),
+      tail_(0),
+      last_time_(t) {}
+
+void TimeBasedCounter::Clear(Tick t) {
+  last_time_ = t;
+  for (size_t i = 0; i < slots_.size(); i++) {
+    slots_[i] = 0;
+  }
+  tail_ = count_ = 0;
+}
+
+void TimeBasedCounter::Roll(Tick t) {
+  auto d = duration_cast<milliseconds>(t - last_time_);
+  uint32_t n = uint32_t(d.count() / slot_duration_.count());
+  if (n >= slots_.size()) {
+    Clear(t);
+    return;
+  }
+
+  for (uint32_t i = 0; i < n; i++) {
+    tail_ = (tail_ + 1) % slots_.size();
+    count_ -= slots_[tail_];
+    slots_[tail_] = 0;
+    last_time_ += slot_duration_;
+  }
+}
+
+void TimeBasedCounter::Inc(int n, Tick t) {
+  Roll(t);
+  slots_[tail_] += n;
+  count_ += n;
+}
+
+int TimeBasedCounter::Count(Tick t) {
+  Roll(t);
+  return count_;
+}
+
+}  // namespace utils
+}  // namespace api_manager
+}  // namespace google

--- a/src/api_manager/utils/time_based_counter.h
+++ b/src/api_manager/utils/time_based_counter.h
@@ -1,0 +1,61 @@
+/* Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef API_MANAGER_UTILS_TIME_BASED_COUNTER_H_
+#define API_MANAGER_UTILS_TIME_BASED_COUNTER_H_
+
+#include <chrono>
+#include <vector>
+
+namespace google {
+namespace api_manager {
+namespace utils {
+
+// Define a counter for the count in a time based window.
+// Each count is associated with a time stamp. The count outside
+// of the window will not be counted.
+class TimeBasedCounter {
+ public:
+  // Define a time stamp type.
+  // Ideally, Now() timestamp should be used inside the functions.
+  // But for easy unit_test, pass the time in.
+  // The input time should be always increasing.
+  typedef std::chrono::time_point<std::chrono::system_clock> Tick;
+
+  TimeBasedCounter(int window_size, std::chrono::milliseconds duration, Tick t);
+
+  // Add n count to the counter.
+  void Inc(int n, Tick t);
+
+  // Get the count.
+  int Count(Tick t);
+
+ private:
+  // Clear the whole window
+  void Clear(Tick t);
+  // Roll the window
+  void Roll(Tick t);
+
+  std::vector<int> slots_;
+  std::chrono::milliseconds slot_duration_;
+  int count_;
+  int tail_;
+  Tick last_time_;
+};
+
+}  // namespace utils
+}  // namespace api_manager
+}  // namespace google
+
+#endif  // API_MANAGER_UTILS_TIME_BASED_COUNTER_H_

--- a/src/api_manager/utils/time_based_counter_test.cc
+++ b/src/api_manager/utils/time_based_counter_test.cc
@@ -1,0 +1,41 @@
+// Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+
+#include "src/api_manager/utils/time_based_counter.h"
+#include "gtest/gtest.h"
+
+namespace google {
+namespace api_manager {
+namespace utils {
+
+std::chrono::time_point<std::chrono::system_clock> FakeTime(int t) {
+  return std::chrono::time_point<std::chrono::system_clock>(
+      std::chrono::milliseconds(t));
+}
+
+TEST(TimeBasedCounterTest, Test1) {
+  TimeBasedCounter c(3, std::chrono::milliseconds(3), FakeTime(0));
+  c.Inc(1, FakeTime(4));
+  c.Inc(1, FakeTime(5));
+  c.Inc(1, FakeTime(7));
+
+  // Current slots are 6, 7, 8. and 4 and 5 are out.
+  ASSERT_EQ(c.Count(FakeTime(8)), 1);
+}
+
+}  // namespace utils
+}  // namespace api_manager
+}  // namespace google


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@gmail.com>

ESP is call ServiceManagement service to check its latest rollout in every minute regardless the ESP is idle or not.

In order to reduce the load to ServiceManagement,  it is better not to make these calls for these Idle ESP instances. 