### PR TITLE
Not to extract api-key and use it if not required

### DIFF
--- a/src/api_manager/context/request_context.cc
+++ b/src/api_manager/context/request_context.cc
@@ -122,7 +122,8 @@ RequestContext::RequestContext(std::shared_ptr<ServiceContext> service_context,
   method_call_ =
       service_context_->GetMethodCallInfo(method, path, query_params);
 
-  if (method_call_.method_info) {
+  if (method_call_.method_info &&
+      !method_call_.method_info->allow_unregistered_calls()) {
     ExtractApiKey();
   }
   request_->FindHeader("referer", &http_referer_);

--- a/src/nginx/t/aggregated_check_report.t
+++ b/src/nginx/t/aggregated_check_report.t
@@ -45,7 +45,7 @@ my $ServiceControlPort = ApiManager::pick_port();
 my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(18);
 
 # Save service name in the service configuration protocol buffer file.
-my $config = ApiManager::get_bookstore_service_config_allow_unregistered .
+my $config = ApiManager::get_bookstore_service_config_allow_some_unregistered .
              ApiManager::read_test_file('testdata/logs_metrics.pb.txt') . <<"EOF";
 control {
   environment: "http://127.0.0.1:${ServiceControlPort}"

--- a/src/nginx/t/check_report_body.t
+++ b/src/nginx/t/check_report_body.t
@@ -45,7 +45,7 @@ my $ServiceControlPort = ApiManager::pick_port();
 my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(16);
 
 # Save service name in the service configuration protocol buffer file.
-my $config = ApiManager::get_bookstore_service_config_allow_unregistered .
+my $config = ApiManager::get_bookstore_service_config_allow_some_unregistered .
              ApiManager::read_test_file('testdata/logs_metrics.pb.txt') . <<"EOF";
 producer_project_id: "endpoints-test"
 control {

--- a/src/nginx/t/cloud_trace.t
+++ b/src/nginx/t/cloud_trace.t
@@ -46,7 +46,7 @@ my $CloudTracePort = ApiManager::pick_port();
 
 my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(29);
 
-my $config = ApiManager::get_bookstore_service_config_allow_unregistered .
+my $config = ApiManager::get_bookstore_service_config_allow_some_unregistered .
     ApiManager::read_test_file('testdata/logs_metrics.pb.txt') . <<"EOF";
 producer_project_id: "api-manager-project"
 control {

--- a/src/nginx/t/fail_wrong_api_key.t
+++ b/src/nginx/t/fail_wrong_api_key.t
@@ -45,7 +45,7 @@ my $ServiceControlPort = ApiManager::pick_port();
 my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(18);
 
 # Save service name in the service configuration protocol buffer file.
-my $config = ApiManager::get_bookstore_service_config_allow_unregistered . <<"EOF";
+my $config = ApiManager::get_bookstore_service_config_allow_some_unregistered . <<"EOF";
 control {
   environment: "http://127.0.0.1:${ServiceControlPort}"
 }

--- a/src/nginx/t/new_http.t
+++ b/src/nginx/t/new_http.t
@@ -50,7 +50,7 @@ my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(22);
 
 # Save service name in the service configuration protocol buffer file.
 $t->write_file('service.pb.txt',
-               ApiManager::get_bookstore_service_config_allow_unregistered . <<"EOF");
+               ApiManager::get_bookstore_service_config_allow_some_unregistered . <<"EOF");
 control {
   environment: "http://127.0.0.1:${ServiceControlPort}"
 }

--- a/src/nginx/t/report_with_geo.t
+++ b/src/nginx/t/report_with_geo.t
@@ -46,7 +46,7 @@ my $ServiceControlPort = ApiManager::pick_port();
 my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(8);
 
 # Save service name in the service configuration protocol buffer file.
-my $config = ApiManager::get_bookstore_service_config_allow_unregistered .
+my $config = ApiManager::get_bookstore_service_config_allow_some_unregistered .
              ApiManager::read_test_file('testdata/logs_metrics.pb.txt') . <<"EOF";
 producer_project_id: "endpoints-test"
 control {

--- a/src/nginx/t/unregistered.t
+++ b/src/nginx/t/unregistered.t
@@ -44,7 +44,7 @@ my $BackendPort = ApiManager::pick_port();
 my $ServiceControlPort = ApiManager::pick_port();
 my $MetadataPort = ApiManager::pick_port();
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(35);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(32);
 
 $t->write_file('server_config.pb.txt', ApiManager::disable_service_control_cache);
 
@@ -183,26 +183,21 @@ sub verify_report {
   }
 }
 
-# 1st call: Check is called since api-key is provided
-# 2nd call: Check is NOT called since api-key is not provided
+# 1st call: Check is NOT called since api-key is not required even it is provided
+# 2nd call: Check is NOT called since api-key is not required nor provided
 # 3rd call: Check is called since api-key is provided
 # 4th call: Check is NOT called since api-key is NOT provided
 # Report are called for all of them.
 my @servicecontrol_requests = ApiManager::read_http_stream($t, 'servicecontrol.log');
-is(scalar @servicecontrol_requests, 6, 'Service control was called 6 times.');
+is(scalar @servicecontrol_requests, 5, 'Service control was called 5 times.');
 
-my ($check1, $report1, $report2, $check3, $report3, $report4) = @servicecontrol_requests;
+my ($report1, $report2, $check3, $report3, $report4) = @servicecontrol_requests;
 
 # /shelves?key=this-is-an-api-key-1
-verify_check($check1,
-            '/shelves?key=this-is-an-api-key',
-            'ListShelves',
-            'api_key:this-is-an-api-key-1');
-
 verify_report($report1,
             '/shelves?key=this-is-an-api-key',
             'ListShelves',
-            'api_key:this-is-an-api-key-1');
+            undef);
 
 like($response1, qr/HTTP\/1\.1 200 OK/, 'Allow unregistered, provide API key - 200 OK');
 like($response1, qr/List of shelves\.$/, 'Allow unregistered, provide API key - body');

--- a/src/nginx/t/unregistered_no_project.t
+++ b/src/nginx/t/unregistered_no_project.t
@@ -43,7 +43,7 @@ my $NginxPort = ApiManager::pick_port();
 my $BackendPort = ApiManager::pick_port();
 my $ServiceControlPort = ApiManager::pick_port();
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(34);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(31);
 
 $t->write_file('server_config.pb.txt', ApiManager::disable_service_control_cache);
 
@@ -177,26 +177,21 @@ sub verify_report {
   }
 }
 
-# 1st call: Check is called since api-key is provided
-# 2nd call: Check is NOT called since api-key is not provided
+# 1st call: Check is NOT called since api-key is not requird even it is provided
+# 2nd call: Check is NOT called since api-key is not required nor provided
 # 3rd call: Check is called since api-key is provided
 # 4th call: Check is NOT called since api-key is NOT provided
 # Report are called for all of them.
 my @servicecontrol_requests = ApiManager::read_http_stream($t, 'servicecontrol.log');
-is(scalar @servicecontrol_requests, 6, 'Service control was called 6 times.');
+is(scalar @servicecontrol_requests, 5, 'Service control was called 5 times.');
 
-my ($check1, $report1, $report2, $check3, $report3, $report4) = @servicecontrol_requests;
+my ($report1, $report2, $check3, $report3, $report4) = @servicecontrol_requests;
 
 # /shelves?key=this-is-an-api-key-1
-verify_check($check1,
-            '/shelves?key=this-is-an-api-key',
-            'ListShelves',
-            'api_key:this-is-an-api-key-1');
-
 verify_report($report1,
             '/shelves?key=this-is-an-api-key',
             'ListShelves',
-            'api_key:this-is-an-api-key-1');
+            undef);
 
 like($response1, qr/HTTP\/1\.1 200 OK/, 'Allow unregistered, provide API key - 200 OK');
 like($response1, qr/List of shelves\.$/, 'Allow unregistered, provide API key - body');


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@gmail.com>

Some users are using ?key=??? for other purposes.  ESP should not use if it it is not required.
