### PR TITLE
Call TryCancel and StartUpstreamFinish when there is a connection error

### DIFF
--- a/src/grpc/proxy_flow.h
+++ b/src/grpc/proxy_flow.h
@@ -82,6 +82,15 @@ class ProxyFlow {
   static void StartDownstreamFinish(std::shared_ptr<ProxyFlow> flow,
                                     utils::Status status);
 
+  // NOTE: For gRPC steaming, at this point client-side streaming is done, but
+  // server-side streaming is not. There needs to be an additional mechanism
+  // to detect RST_STREAM and finish upstream properly. This problem can arise
+  // for server-side streaming when ESP is connected with connection pooling
+  // and multiple requests share a single HTTP connection.
+  // This function must be called when `sent_upstream_writes_done_` is set to
+  // true.
+  static void RegisterGrpcUpstreamCancel(std::shared_ptr<ProxyFlow> flow);
+
   std::mutex mu_;
 
   // If true, the downstream side is no longer sending data, and a

--- a/src/grpc/server_call.h
+++ b/src/grpc/server_call.h
@@ -61,6 +61,7 @@ class ServerCall {
 
   virtual void UpdateRequestMessageStat(int64_t size) = 0;
   virtual void UpdateResponseMessageStat(int64_t size) = 0;
+  virtual void SetCancel(std::function<void()> cancel) = 0;
 };
 
 }  // namespace grpc

--- a/src/grpc/server_call.h
+++ b/src/grpc/server_call.h
@@ -61,7 +61,8 @@ class ServerCall {
 
   virtual void UpdateRequestMessageStat(int64_t size) = 0;
   virtual void UpdateResponseMessageStat(int64_t size) = 0;
-  virtual void SetCancel(std::function<void()> cancel) = 0;
+  virtual void SetGrpcUpstreamCancel(
+      std::function<void()> grpc_upstream_cancel) = 0;
 };
 
 }  // namespace grpc

--- a/src/nginx/grpc_server_call.cc
+++ b/src/nginx/grpc_server_call.cc
@@ -362,8 +362,9 @@ void NgxEspGrpcServerCall::OnHttpBlockReading(ngx_http_request_t *r) {
 
     ngx_esp_request_ctx_t *ctx = ngx_http_esp_ensure_module_ctx(r);
     if (ctx->grpc_upstream_cancel) {
-      // std::swap(grpc_upstream_cancel, ctx->grpc_upstream_cancel);
-      (*ctx->grpc_upstream_cancel)();
+      std::function<void()> *grpc_upstream_cancel =
+          ctx->grpc_upstream_cancel.release();
+      (*grpc_upstream_cancel)();
     }
   }
 

--- a/src/nginx/grpc_server_call.cc
+++ b/src/nginx/grpc_server_call.cc
@@ -362,9 +362,9 @@ void NgxEspGrpcServerCall::OnHttpBlockReading(ngx_http_request_t *r) {
 
     ngx_esp_request_ctx_t *ctx = ngx_http_esp_ensure_module_ctx(r);
     if (ctx->grpc_upstream_cancel) {
-      std::function<void()> *grpc_upstream_cancel =
-          ctx->grpc_upstream_cancel.release();
-      (*grpc_upstream_cancel)();
+      std::unique_ptr<std::function<void()>> cancel_func_ptr;
+      std::swap(ctx->grpc_upstream_cancel, cancel_func_ptr);
+      (*cancel_func_ptr)();
     }
   }
 

--- a/src/nginx/grpc_server_call.cc
+++ b/src/nginx/grpc_server_call.cc
@@ -217,6 +217,10 @@ void NgxEspGrpcServerCall::UpdateResponseMessageStat(int64_t size) {
   ctx->request_handler->AttemptIntermediateReport();
 }
 
+void NgxEspGrpcServerCall::SetCancel(std::function<void()> cancel) {
+  cancel_ = cancel;
+}
+
 void NgxEspGrpcServerCall::AddInitialMetadata(const std::string &key,
                                               const std::string &value) {
   if (!cln_.data) {
@@ -341,6 +345,26 @@ void NgxEspGrpcServerCall::OnDownstreamWriteable(ngx_http_request_t *r) {
   }
 }
 
+void NgxEspGrpcServerCall::OnHttpBlockReading(ngx_http_request_t *r) {
+  ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                 "NgxEspGrpcServerCall::OnHttpBlockReading");
+
+  if (r->connection->error){
+    ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r->connection->log, 0,
+                   "NgxEspGrpcServerCall::OnHttpBlockReading: connection error");
+
+    ngx_esp_request_ctx_t *ctx = ngx_http_esp_ensure_module_ctx(r);
+    NgxEspGrpcServerCall *server_call = ctx->grpc_server_call;
+    if (server_call->cancel_) {
+        std::function<void()> cancel;
+        std::swap(cancel, server_call->cancel_);
+        cancel();
+    }
+  }
+
+  ngx_http_block_reading(r);
+}
+
 // This is the proxy's nginx post_handler (i.e. it's passed to
 // ngx_http_read_client_request_body to get data flowing from nginx to
 // this module)
@@ -364,7 +388,7 @@ void NgxEspGrpcServerCall::OnDownstreamPreread(ngx_http_request_t *r) {
     return;
   }
 
-  r->read_event_handler = &ngx_http_block_reading;
+  r->read_event_handler = &OnHttpBlockReading;
 }
 
 // This is the proxy's nginx read_event_handler which will be invoked once
@@ -524,7 +548,7 @@ void NgxEspGrpcServerCall::RunPendingRead() {
     // continuation, so that flow control works correctly.
     ngx_log_debug0(NGX_LOG_DEBUG_HTTP, r_->connection->log, 0,
                    "NgxEspGrpcServerCall::RunPendingRead: Blocking reads");
-    r_->read_event_handler = &ngx_http_block_reading;
+    r_->read_event_handler = &OnHttpBlockReading;
   }
 }
 
@@ -737,6 +761,10 @@ void NgxEspGrpcServerCall::Cleanup(void *server_call_ptr) {
     server_call->CompletePendingRead(false, utils::Status::OK);
   }
   server_call->cln_.data = nullptr;
+  if (server_call->cancel_) {
+    std::function<void()> cancel;
+    std::swap(server_call->cancel_, cancel);
+  }
 }
 
 grpc_byte_buffer *NgxEspGrpcServerCall::ConvertByteBuffer(

--- a/src/nginx/grpc_server_call.h
+++ b/src/nginx/grpc_server_call.h
@@ -76,7 +76,8 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
 
   virtual void UpdateRequestMessageStat(int64_t size);
   virtual void UpdateResponseMessageStat(int64_t size);
-  virtual void SetCancel(std::function<void()> cancel);
+  virtual void SetGrpcUpstreamCancel(
+      std::function<void()> grpc_upstream_cancel);
 
  protected:
   // Converts the request body into gRPC messages and outputs the raw slices.
@@ -115,7 +116,7 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
   static void OnDownstreamPreread(ngx_http_request_t* r);
   static void OnDownstreamReadable(ngx_http_request_t* r);
   static void OnDownstreamWriteable(ngx_http_request_t* r);
-  static void OnHttpBlockReading(ngx_http_request_t *r);
+  static void OnHttpBlockReading(ngx_http_request_t* r);
 
   void CompletePendingRead(bool proceed, utils::Status status);
 
@@ -136,7 +137,7 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
   bool reading_;
   std::function<void(bool)> write_continuation_;
   std::function<void(bool, utils::Status)> read_continuation_;
-  std::function<void()> cancel_;
+  std::function<void()> grpc_upstream_cancel_;
   ::grpc::ByteBuffer* read_msg_;
   ::std::vector<grpc_slice> downstream_slices_;
 

--- a/src/nginx/grpc_server_call.h
+++ b/src/nginx/grpc_server_call.h
@@ -137,7 +137,6 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
   bool reading_;
   std::function<void(bool)> write_continuation_;
   std::function<void(bool, utils::Status)> read_continuation_;
-  std::function<void()> grpc_upstream_cancel_;
   ::grpc::ByteBuffer* read_msg_;
   ::std::vector<grpc_slice> downstream_slices_;
 

--- a/src/nginx/grpc_server_call.h
+++ b/src/nginx/grpc_server_call.h
@@ -76,6 +76,7 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
 
   virtual void UpdateRequestMessageStat(int64_t size);
   virtual void UpdateResponseMessageStat(int64_t size);
+  virtual void SetCancel(std::function<void()> cancel);
 
  protected:
   // Converts the request body into gRPC messages and outputs the raw slices.
@@ -114,6 +115,7 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
   static void OnDownstreamPreread(ngx_http_request_t* r);
   static void OnDownstreamReadable(ngx_http_request_t* r);
   static void OnDownstreamWriteable(ngx_http_request_t* r);
+  static void OnHttpBlockReading(ngx_http_request_t *r);
 
   void CompletePendingRead(bool proceed, utils::Status status);
 
@@ -134,6 +136,7 @@ class NgxEspGrpcServerCall : public grpc::ServerCall {
   bool reading_;
   std::function<void(bool)> write_continuation_;
   std::function<void(bool, utils::Status)> read_continuation_;
+  std::function<void()> cancel_;
   ::grpc::ByteBuffer* read_msg_;
   ::std::vector<grpc_slice> downstream_slices_;
 

--- a/src/nginx/module.h
+++ b/src/nginx/module.h
@@ -223,6 +223,9 @@ struct ngx_esp_request_ctx_s {
 
   // GRPC Proxying support.
   NgxEspGrpcServerCall *grpc_server_call;
+  // For canceling grpc upstream.
+  std::unique_ptr<std::function<void()>> grpc_upstream_cancel;
+
   // Mark if this request is grpc pass through.
   bool grpc_pass_through;
   // Mark the backend is grpc.


### PR DESCRIPTION
An attempt to fix #504. 

Currently, when ESP is connected with connection pooling, there is no mechanism to detect network connection issue/error. 