### PR TITLE
Split cloud_trace.[h|cc] into sampler/aggregator/cloud_trace.

### DIFF
--- a/src/api_manager/cloud_trace/BUILD
+++ b/src/api_manager/cloud_trace/BUILD
@@ -20,14 +20,44 @@ cc_library(
     name = "cloud_trace",
     srcs = [
         "cloud_trace.cc",
+    ],
+    hdrs = [
         "cloud_trace.h",
     ],
     deps = [
+        ":aggregator",
+        ":sampler",
         "//external:absl_base_endian",
         "//external:absl_strings",
         "//external:cloud_trace",
         "//include:headers_only",
         "//src/api_manager/auth:service_account_token",
+    ],
+)
+
+cc_library(
+    name = "aggregator",
+    srcs = [
+        "aggregator.cc",
+    ],
+    hdrs = [
+        "aggregator.h",
+    ],
+    deps = [
+        ":sampler",
+        "//external:cloud_trace",
+        "//include:headers_only",
+        "//src/api_manager/auth:service_account_token",
+    ],
+)
+
+cc_library(
+    name = "sampler",
+    srcs = [
+        "sampler.cc",
+    ],
+    hdrs = [
+        "sampler.h",
     ],
 )
 
@@ -54,7 +84,7 @@ cc_test(
     ],
     linkstatic = 1,
     deps = [
-        ":cloud_trace",
+        ":sampler",
         "//external:googletest_main",
     ],
 )

--- a/src/api_manager/cloud_trace/aggregator.cc
+++ b/src/api_manager/cloud_trace/aggregator.cc
@@ -1,0 +1,117 @@
+// Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+#include "src/api_manager/cloud_trace/aggregator.h"
+
+#include "src/api_manager/utils/marshalling.h"
+
+using google::api_manager::utils::Status;
+using google::devtools::cloudtrace::v1::Traces;
+using google::devtools::cloudtrace::v1::Trace;
+
+namespace google {
+namespace api_manager {
+namespace cloud_trace {
+namespace {
+
+const char kCloudTraceService[] = "/google.devtools.cloudtrace.v1.TraceService";
+
+}  // namespace
+
+Aggregator::Aggregator(auth::ServiceAccountToken *sa_token,
+                       const std::string &cloud_trace_address,
+                       int aggregate_time_millisec, int cache_max_size,
+                       double minimum_qps, ApiManagerEnvInterface *env)
+    : sa_token_(sa_token),
+      cloud_trace_address_(cloud_trace_address),
+      aggregate_time_millisec_(aggregate_time_millisec),
+      cache_max_size_(cache_max_size),
+      traces_(new Traces),
+      env_(env),
+      sampler_(minimum_qps) {
+  sa_token_->SetAudience(auth::ServiceAccountToken::JWT_TOKEN_FOR_CLOUD_TRACING,
+                         cloud_trace_address_ + kCloudTraceService);
+}
+
+void Aggregator::Init() {
+  if (aggregate_time_millisec_ == 0) {
+    return;
+  }
+  timer_ = env_->StartPeriodicTimer(
+      std::chrono::milliseconds(aggregate_time_millisec_),
+      [this]() { SendAndClearTraces(); });
+}
+
+Aggregator::~Aggregator() {
+  if (timer_) {
+    timer_->Stop();
+  }
+}
+
+void Aggregator::SendAndClearTraces() {
+  if (traces_->traces_size() == 0 || project_id_.empty()) {
+    env_->LogDebug(
+        "Not sending request to CloudTrace: no traces or "
+        "project_id is empty.");
+    traces_->clear_traces();
+    return;
+  }
+
+  // Add project id into each trace object.
+  for (int i = 0; i < traces_->traces_size(); ++i) {
+    traces_->mutable_traces(i)->set_project_id(project_id_);
+  }
+
+  std::unique_ptr<HTTPRequest> http_request(new HTTPRequest(
+      [this](Status status, std::map<std::string, std::string> &&,
+             std::string &&body) {
+        if (status.code() < 0) {
+          env_->LogError("Trace Request Failed." + status.ToString());
+        } else {
+          env_->LogDebug("Trace Response: " + status.ToString() + "\n" + body);
+        }
+      }));
+
+  std::string url =
+      cloud_trace_address_ + "/v1/projects/" + project_id_ + "/traces";
+
+  std::string request_body;
+
+  ProtoToJson(*traces_, &request_body, utils::DEFAULT);
+  traces_->clear_traces();
+  env_->LogDebug("Sending request to Cloud Trace.");
+  env_->LogDebug(request_body);
+
+  http_request->set_url(url)
+      .set_method("PATCH")
+      .set_auth_token(sa_token_->GetAuthToken(
+          auth::ServiceAccountToken::JWT_TOKEN_FOR_CLOUD_TRACING))
+      .set_header("Content-Type", "application/json")
+      .set_body(request_body);
+
+  env_->RunHTTPRequest(std::move(http_request));
+}
+
+void Aggregator::AppendTrace(Trace *trace) {
+  traces_->mutable_traces()->AddAllocated(trace);
+  if (traces_->traces_size() > cache_max_size_) {
+    SendAndClearTraces();
+  }
+}
+
+}  // cloud_trace
+}  // namespace api_manager
+}  // namespace google

--- a/src/api_manager/cloud_trace/aggregator.h
+++ b/src/api_manager/cloud_trace/aggregator.h
@@ -1,0 +1,92 @@
+/* Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//
+#ifndef API_MANAGER_CLOUD_TRACE_AGGREGATOR_H_
+#define API_MANAGER_CLOUD_TRACE_AGGREGATOR_H_
+
+#include "google/devtools/cloudtrace/v1/trace.pb.h"
+#include "include/api_manager/periodic_timer.h"
+#include "include/api_manager/env_interface.h"
+#include "src/api_manager/auth/service_account_token.h"
+#include "src/api_manager/cloud_trace/sampler.h"
+
+namespace google {
+namespace api_manager {
+namespace cloud_trace {
+
+// TODO: The Aggregator class is not thread safe.
+// TODO: simplify class naming in this file.
+// Stores cloud trace configurations shared within the job. There should be
+// only one such instance. The instance is put in service_context.
+class Aggregator final {
+ public:
+  Aggregator(auth::ServiceAccountToken *sa_token,
+             const std::string &cloud_trace_address,
+             int aggregate_time_millisec, int cache_max_size,
+             double minimum_qps, ApiManagerEnvInterface *env);
+
+  ~Aggregator();
+
+  // Initializes the aggregator by setting up a periodic timer. At each timer
+  // invocation traces aggregated are sent to Cloud Trace API
+  void Init();
+
+  // Flush traces cached and clear the traces_ proto.
+  void SendAndClearTraces();
+
+  // Append a Trace to traces_, the appended trace may not be sent at the time
+  // of this function call.
+  void AppendTrace(google::devtools::cloudtrace::v1::Trace *trace);
+
+  // Sets the producer project id
+  void SetProjectId(const std::string &project_id) { project_id_ = project_id; }
+
+  // Get the sampler.
+  Sampler &sampler() { return sampler_; }
+
+ private:
+  // ServiceAccountToken object to get auth tokens for Cloud Trace API.
+  auth::ServiceAccountToken *sa_token_;
+
+  // Address for Cloud Trace API
+  std::string cloud_trace_address_;
+
+  // The maximum time to hold a trace before sent to Cloud Trace.
+  int aggregate_time_millisec_;
+
+  // The maximum number of traces that can be cached.
+  int cache_max_size_;
+
+  // Traces protobuf to hold a list of Trace obejcts.
+  std::unique_ptr<google::devtools::cloudtrace::v1::Traces> traces_;
+
+  // The producer project id.
+  std::string project_id_;
+
+  // ApiManager Env used to set up periodic timer.
+  ApiManagerEnvInterface *env_;
+
+  // Timer to trigger flush trace.
+  std::unique_ptr<google::api_manager::PeriodicTimer> timer_;
+
+  // Sampler object to help determine if trace should be enabled for a request.
+  Sampler sampler_;
+};
+
+}  // cloud_trace
+}  // api_manager
+}  // google
+
+#endif  // API_MANAGER_CLOUD_TRACE_AGGREGATOR_H_

--- a/src/api_manager/cloud_trace/aggregator.h
+++ b/src/api_manager/cloud_trace/aggregator.h
@@ -17,8 +17,8 @@
 #define API_MANAGER_CLOUD_TRACE_AGGREGATOR_H_
 
 #include "google/devtools/cloudtrace/v1/trace.pb.h"
-#include "include/api_manager/periodic_timer.h"
 #include "include/api_manager/env_interface.h"
+#include "include/api_manager/periodic_timer.h"
 #include "src/api_manager/auth/service_account_token.h"
 #include "src/api_manager/cloud_trace/sampler.h"
 

--- a/src/api_manager/cloud_trace/cloud_trace.cc
+++ b/src/api_manager/cloud_trace/cloud_trace.cc
@@ -14,7 +14,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 //
-#include "cloud_trace.h"
+#include "src/api_manager/cloud_trace/cloud_trace.h"
 
 #include <cctype>
 #include <chrono>
@@ -27,11 +27,8 @@
 #include "google/protobuf/timestamp.pb.h"
 #include "include/api_manager/utils/status.h"
 #include "include/api_manager/utils/version.h"
-#include "src/api_manager/utils/marshalling.h"
 
-using google::api_manager::utils::Status;
 using google::devtools::cloudtrace::v1::Trace;
-using google::devtools::cloudtrace::v1::Traces;
 using google::devtools::cloudtrace::v1::TraceSpan;
 using google::devtools::cloudtrace::v1::TraceSpan_SpanKind;
 using google::protobuf::Timestamp;
@@ -41,7 +38,6 @@ namespace api_manager {
 namespace cloud_trace {
 namespace {
 
-const char kCloudTraceService[] = "/google.devtools.cloudtrace.v1.TraceService";
 // Cloud Trace agent label key
 const char kCloudTraceAgentKey[] = "trace.cloud.google.com/agent";
 // Cloud Trace agent label value
@@ -92,117 +88,6 @@ void GetTraceFromGRpcTraceContextHeader(const std::string &raw_trace_context,
                                         const std::string &root_span_name,
                                         Trace **trace, std::string *options);
 }  // namespace
-
-Sampler::Sampler(double qps) {
-  if (qps == 0.0) {
-    is_disabled_ = true;
-  } else {
-    duration_ = 1.0 / qps;
-    is_disabled_ = false;
-  }
-}
-
-bool Sampler::On() {
-  if (is_disabled_) {
-    return false;
-  }
-  auto now = std::chrono::system_clock::now();
-  std::chrono::duration<double> diff = now - previous_;
-  if (diff.count() > duration_) {
-    previous_ = now;
-    return true;
-  } else {
-    return false;
-  }
-};
-
-void Sampler::Refresh() {
-  if (is_disabled_) {
-    return;
-  }
-  previous_ = std::chrono::system_clock::now();
-}
-
-Aggregator::Aggregator(auth::ServiceAccountToken *sa_token,
-                       const std::string &cloud_trace_address,
-                       int aggregate_time_millisec, int cache_max_size,
-                       double minimum_qps, ApiManagerEnvInterface *env)
-    : sa_token_(sa_token),
-      cloud_trace_address_(cloud_trace_address),
-      aggregate_time_millisec_(aggregate_time_millisec),
-      cache_max_size_(cache_max_size),
-      traces_(new Traces),
-      env_(env),
-      sampler_(minimum_qps) {
-  sa_token_->SetAudience(auth::ServiceAccountToken::JWT_TOKEN_FOR_CLOUD_TRACING,
-                         cloud_trace_address_ + kCloudTraceService);
-}
-
-void Aggregator::Init() {
-  if (aggregate_time_millisec_ == 0) {
-    return;
-  }
-  timer_ = env_->StartPeriodicTimer(
-      std::chrono::milliseconds(aggregate_time_millisec_),
-      [this]() { SendAndClearTraces(); });
-}
-
-Aggregator::~Aggregator() {
-  if (timer_) {
-    timer_->Stop();
-  }
-}
-
-void Aggregator::SendAndClearTraces() {
-  if (traces_->traces_size() == 0 || project_id_.empty()) {
-    env_->LogDebug(
-        "Not sending request to CloudTrace: no traces or "
-        "project_id is empty.");
-    traces_->clear_traces();
-    return;
-  }
-
-  // Add project id into each trace object.
-  for (int i = 0; i < traces_->traces_size(); ++i) {
-    traces_->mutable_traces(i)->set_project_id(project_id_);
-  }
-
-  std::unique_ptr<HTTPRequest> http_request(new HTTPRequest(
-      [this](Status status, std::map<std::string, std::string> &&,
-             std::string &&body) {
-        if (status.code() < 0) {
-          env_->LogError("Trace Request Failed." + status.ToString());
-        } else {
-          env_->LogDebug("Trace Response: " + status.ToString() + "\n" + body);
-        }
-      }));
-
-  std::string url =
-      cloud_trace_address_ + "/v1/projects/" + project_id_ + "/traces";
-
-  std::string request_body;
-
-  ProtoToJson(*traces_, &request_body, utils::DEFAULT);
-  traces_->clear_traces();
-  env_->LogDebug("Sending request to Cloud Trace.");
-  env_->LogDebug(request_body);
-
-  http_request->set_url(url)
-      .set_method("PATCH")
-      .set_auth_token(sa_token_->GetAuthToken(
-          auth::ServiceAccountToken::JWT_TOKEN_FOR_CLOUD_TRACING))
-      .set_header("Content-Type", "application/json")
-      .set_body(request_body);
-
-  env_->RunHTTPRequest(std::move(http_request));
-}
-
-void Aggregator::AppendTrace(google::devtools::cloudtrace::v1::Trace *trace) {
-  traces_->mutable_traces()->AddAllocated(trace);
-  if (traces_->traces_size() > cache_max_size_) {
-    SendAndClearTraces();
-  }
-}
 
 CloudTrace::CloudTrace(Trace *trace, const std::string &options,
                        HeaderType header_type)
@@ -284,11 +169,11 @@ CloudTraceSpan::~CloudTraceSpan() {
     return;
   }
   GetNow(trace_span_->mutable_end_time());
-  for (unsigned int i = 0; i < messages.size(); ++i) {
+  for (unsigned int i = 0; i < messages_.size(); ++i) {
     std::stringstream stream;
     stream << std::setfill('0') << std::setw(3) << i;
     std::string sequence = stream.str();
-    trace_span_->mutable_labels()->insert({sequence, messages[i]});
+    trace_span_->mutable_labels()->insert({sequence, messages_[i]});
   }
 }
 
@@ -297,7 +182,7 @@ void CloudTraceSpan::Write(const std::string &msg) {
     // Trace is disabled.
     return;
   }
-  messages.push_back(msg);
+  messages_.push_back(msg);
 }
 
 CloudTrace *CreateCloudTrace(const std::string &trace_context,

--- a/src/api_manager/cloud_trace/cloud_trace.h
+++ b/src/api_manager/cloud_trace/cloud_trace.h
@@ -21,9 +21,8 @@
 
 #include "google/devtools/cloudtrace/v1/trace.pb.h"
 #include "google/protobuf/map.h"
-#include "include/api_manager/env_interface.h"
-#include "include/api_manager/periodic_timer.h"
-#include "src/api_manager/auth/service_account_token.h"
+#include "src/api_manager/cloud_trace/aggregator.h"
+#include "src/api_manager/cloud_trace/sampler.h"
 
 namespace google {
 namespace api_manager {
@@ -32,86 +31,6 @@ namespace cloud_trace {
 enum HeaderType {
   CLOUD_TRACE_CONTEXT = 1,
   GRPC_TRACE_CONTEXT = 2,
-};
-
-// A helper class to determine if trace should be enabled for a request.
-// A Sampler instance is put into the Aggregator class.
-// Trace is triggered if the time interval between the request time and the
-// previous trace enabled request is bigger than a threshold.
-// The threshold is calculated from the qps.
-class Sampler {
- public:
-  Sampler(double qps);
-
-  // Returns whether trace should be turned on for this request.
-  bool On();
-
-  // Refresh the previous timestamp to the current time.
-  void Refresh();
-
- private:
-  bool is_disabled_;
-  std::chrono::time_point<std::chrono::system_clock> previous_;
-  double duration_;
-};
-
-// TODO: The Aggregator class is not thread safe.
-// TODO: simplify class naming in this file.
-// Stores cloud trace configurations shared within the job. There should be
-// only one such instance. The instance is put in service_context.
-class Aggregator final {
- public:
-  Aggregator(auth::ServiceAccountToken *sa_token,
-             const std::string &cloud_trace_address,
-             int aggregate_time_millisec, int cache_max_size,
-             double minimum_qps, ApiManagerEnvInterface *env);
-
-  ~Aggregator();
-
-  // Initializes the aggregator by setting up a periodic timer. At each timer
-  // invocation traces aggregated are sent to Cloud Trace API
-  void Init();
-
-  // Flush traces cached and clear the traces_ proto.
-  void SendAndClearTraces();
-
-  // Append a Trace to traces_, the appended trace may not be sent at the time
-  // of this function call.
-  void AppendTrace(google::devtools::cloudtrace::v1::Trace *trace);
-
-  // Sets the producer project id
-  void SetProjectId(const std::string &project_id) { project_id_ = project_id; }
-
-  // Get the sampler.
-  Sampler &sampler() { return sampler_; }
-
- private:
-  // ServiceAccountToken object to get auth tokens for Cloud Trace API.
-  auth::ServiceAccountToken *sa_token_;
-
-  // Address for Cloud Trace API
-  std::string cloud_trace_address_;
-
-  // The maximum time to hold a trace before sent to Cloud Trace.
-  int aggregate_time_millisec_;
-
-  // The maximum number of traces that can be cached.
-  int cache_max_size_;
-
-  // Traces protobuf to hold a list of Trace obejcts.
-  std::unique_ptr<google::devtools::cloudtrace::v1::Traces> traces_;
-
-  // The producer project id.
-  std::string project_id_;
-
-  // ApiManager Env used to set up periodic timer.
-  ApiManagerEnvInterface *env_;
-
-  // Timer to trigger flush trace.
-  std::unique_ptr<google::api_manager::PeriodicTimer> timer_;
-
-  // Sampler object to help determine if trace should be enabled for a request.
-  Sampler sampler_;
 };
 
 // Stores traces and metadata for one request. The instance of this class is
@@ -191,7 +110,7 @@ class CloudTraceSpan {
                             protobuf::uint64 parent_span_id);
   CloudTrace *cloud_trace_;
   google::devtools::cloudtrace::v1::TraceSpan *trace_span_;
-  std::vector<std::string> messages;
+  std::vector<std::string> messages_;
 };
 
 // Parses the trace_context and determines if cloud trace should

--- a/src/api_manager/cloud_trace/sampler.cc
+++ b/src/api_manager/cloud_trace/sampler.cc
@@ -1,0 +1,55 @@
+// Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+#include "src/api_manager/cloud_trace/sampler.h"
+
+namespace google {
+namespace api_manager {
+namespace cloud_trace {
+
+Sampler::Sampler(double qps) {
+  if (qps == 0.0) {
+    is_disabled_ = true;
+  } else {
+    duration_ = 1.0 / qps;
+    is_disabled_ = false;
+  }
+}
+
+bool Sampler::On() {
+  if (is_disabled_) {
+    return false;
+  }
+  auto now = std::chrono::system_clock::now();
+  std::chrono::duration<double> diff = now - previous_;
+  if (diff.count() > duration_) {
+    previous_ = now;
+    return true;
+  } else {
+    return false;
+  }
+};
+
+void Sampler::Refresh() {
+  if (is_disabled_) {
+    return;
+  }
+  previous_ = std::chrono::system_clock::now();
+}
+
+}  // cloud_trace
+}  // namespace api_manager
+}  // namespace google

--- a/src/api_manager/cloud_trace/sampler.h
+++ b/src/api_manager/cloud_trace/sampler.h
@@ -1,0 +1,50 @@
+/* Copyright (C) Extensible Service Proxy Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//
+#ifndef API_MANAGER_CLOUD_TRACE_SAMPLER_H_
+#define API_MANAGER_CLOUD_TRACE_SAMPLER_H_
+
+#include <chrono>
+
+namespace google {
+namespace api_manager {
+namespace cloud_trace {
+
+// A helper class to determine if trace should be enabled for a request.
+// A Sampler instance is put into the Aggregator class.
+// Trace is triggered if the time interval between the request time and the
+// previous trace enabled request is bigger than a threshold.
+// The threshold is calculated from the qps.
+class Sampler {
+ public:
+  Sampler(double qps);
+
+  // Returns whether trace should be turned on for this request.
+  bool On();
+
+  // Refresh the previous timestamp to the current time.
+  void Refresh();
+
+ private:
+  bool is_disabled_;
+  std::chrono::time_point<std::chrono::system_clock> previous_;
+  double duration_;
+};
+
+}  // cloud_trace
+}  // api_manager
+}  // google
+
+#endif  // API_MANAGER_CLOUD_TRACE_SAMPLER_H_

--- a/src/api_manager/cloud_trace/sampler_test.cc
+++ b/src/api_manager/cloud_trace/sampler_test.cc
@@ -14,15 +14,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 //
-#include "src/api_manager/cloud_trace/cloud_trace.h"
+#include "src/api_manager/cloud_trace/sampler.h"
 
 #include <chrono>
 #include <thread>
 
-#include "google/devtools/cloudtrace/v1/trace.pb.h"
 #include "gtest/gtest.h"
-
-using google::devtools::cloudtrace::v1::TraceSpan;
 
 namespace google {
 namespace api_manager {


### PR DESCRIPTION
This change allows us to make granular and isolated changes in some of the classes. The cloud_trace.[h|cc] had a lot of logic inside.

This PR does not contain any changes in the current logic, only code moved to smaller files.