### PR TITLE
Improve env variable handling in serverless image startup script.

### DIFF
--- a/docker/serverless/env-start-esp.py
+++ b/docker/serverless/env-start-esp.py
@@ -29,6 +29,11 @@
 
 import os
 
+CMD = "/usr/sbin/start_esp"
+
+# The command being run must be the 0th arg.
+ARGS = [CMD, "--enable_backend_routing"]
+
 _ENV_ERROR = "Serverless ESP expects {} in environment variables."
 
 try:
@@ -36,24 +41,44 @@ try:
 except ValueError:
     raise ApplicationError(_ENV_ERROR.format("PORT"))
 
+ARGS.append("--http_port={}".format(PORT))
+
 try:
-    SERVICE_NAME = os.environ["SERVICE_NAME"]
+    SERVICE = os.environ["ENDPOINTS_SERVICE_NAME"]
 except ValueError:
-    raise ApplicationError(_ENV_ERROR.format("SERVICE_NAME"))
+    raise ApplicationError(_ENV_ERROR.format("ENDPOINTS_SERVICE_NAME"))
 
-CMD = "/usr/sbin/start_esp"
+ARGS.append("--service={}".format(SERVICE))
 
-ARGS = [
-    CMD,
-    "--http_port={}".format(PORT),
-    "--service={}".format(SERVICE_NAME),
-    "--enable_backend_routing",
-]
-
-if "ESP_ARGS" in os.environ:
-    ARGS.extend(os.environ["ESP_ARGS"].split(","))
+if "ENDPOINTS_SERVICE_VERSION" in os.environ:
+    ARGS.extend(
+        [
+            "--rollout_strategy=fixed",
+            "--version={}".format(os.environ["ENDPOINTS_SERVICE_VERSION"]),
+        ]
+    )
 else:
     ARGS.append("--rollout_strategy=managed")
+
+if "CORS_PRESET" in os.environ:
+    ARGS.append("--cors_preset={}".format(os.environ["CORS_PRESET"]))
+
+if "ESP_ARGS" in os.environ:
+    # By default, ESP_ARGS is comma-separated.
+    # But if a comma needs to appear within an arg, there is an alternative
+    # syntax: Pick a replacement delimiter, specify it at the beginning of the
+    # string between two caret (^) symbols, and use it within the arg string.
+    # Example:
+    # ^++^--cors_allow_methods="GET,POST,PUT,OPTIONS"++--cors_allow_credentials
+    arg_value = os.environ["ESP_ARGS"]
+
+    delim = ","
+    if arg_value.startswith("^") and "^" in arg_value[1:]:
+        delim, arg_value = arg_value[1:].split("^", 1)
+    if not delim:
+        raise ApplicationError("Malformed ESP_ARGS environment variable.")
+
+    ARGS.extend(arg_value.split(delim))
 
 
 os.execv(CMD, ARGS)


### PR DESCRIPTION
The 'SERVICE_NAME' variable is renamed 'ENDPOINTS_SERVICE_NAME' for
clarity. 'ENDPOINTS_SERVICE_VERSION' is a new optional env variable
which changes rollout strategy to fixed and specifies the version.

'CORS_PRESET' is a new optional env variable for the CORS preset
command line option. Also, 'ESP_ARGS' supports specifying a delimiter
other than the comma; this works the same way as in gcloud.