### PR TITLE
nginx: fix type mismatch during compilation on macOS/OS X

### DIFF
--- a/src/nginx/grpc_web_finish.cc
+++ b/src/nginx/grpc_web_finish.cc
@@ -91,7 +91,7 @@ ngx_chain_t *AppendToEnd(ngx_http_request_t *r, ngx_chain_t *chain,
 }
 
 ngx_chain_t *EncodesGrpcStatusCode(ngx_http_request_t *r, const Code &code,
-                                   size_t *length) {
+                                   uint64_t *length) {
   ngx_chain_t *ngx_chain_status = ngx_alloc_chain_link(r->pool);
   size_t size = snprintf(nullptr, 0, kGrpcStatus, code);
   uint8_t *buffer = static_cast<uint8_t *>(ngx_palloc(r->pool, size + 1));
@@ -115,7 +115,7 @@ ngx_chain_t *EncodesGrpcStatusCode(ngx_http_request_t *r, const Code &code,
 }
 
 ngx_chain_t *EncodesGrpcMessage(ngx_http_request_t *r,
-                                const std::string &message, size_t *length) {
+                                const std::string &message, uint64_t *length) {
   ngx_chain_t *ngx_chain_message = ngx_alloc_chain_link(r->pool);
   size_t size = snprintf(nullptr, 0, kGrpcMessage, message.c_str());
   uint8_t *buffer = static_cast<uint8_t *>(ngx_palloc(r->pool, size + 1));
@@ -141,7 +141,7 @@ ngx_chain_t *EncodesGrpcMessage(ngx_http_request_t *r,
 
 ngx_chain_t *EncodesGrpcCustomTrailers(
     ngx_http_request_t *r, std::multimap<std::string, std::string> &trailers,
-    ngx_chain_t *output, size_t *length) {
+    ngx_chain_t *output, uint64_t *length) {
   if (output == nullptr) {
     return nullptr;
   }


### PR DESCRIPTION
Whenever building on macOS/OS X, the following would happen:

```
src/nginx/grpc_web_finish.cc:235:7: error: no matching function for call to 'EncodesGrpcStatusCode'
      EncodesGrpcStatusCode(r, status.CanonicalCode(), &length);
      ^~~~~~~~~~~~~~~~~~~~~
src/nginx/grpc_web_finish.cc:93:14: note: candidate function not viable: no known conversion from 'uint64_t *' (aka 'unsigned long long *') to 'size_t *' (aka 'unsigned long *') for 3rd argument
ngx_chain_t *EncodesGrpcStatusCode(ngx_http_request_t *r, const Code &code,
             ^
src/nginx/grpc_web_finish.cc:241:20: error: no matching function for call to 'EncodesGrpcMessage'
    grpc_message = EncodesGrpcMessage(r, status.message(), &length);
                   ^~~~~~~~~~~~~~~~~~
src/nginx/grpc_web_finish.cc:117:14: note: candidate function not viable: no known conversion from 'uint64_t *' (aka 'unsigned long long *') to 'size_t *' (aka 'unsigned long *') for 3rd argument
ngx_chain_t *EncodesGrpcMessage(ngx_http_request_t *r,
             ^
src/nginx/grpc_web_finish.cc:257:9: error: no matching function for call to 'EncodesGrpcCustomTrailers'
        EncodesGrpcCustomTrailers(r, response_trailers, trailers, &length);
        ^~~~~~~~~~~~~~~~~~~~~~~~~
src/nginx/grpc_web_finish.cc:142:14: note: candidate function not viable: no known conversion from 'uint64_t *' (aka 'unsigned long long *') to 'size_t *' (aka 'unsigned long *') for 4th argument
ngx_chain_t *EncodesGrpcCustomTrailers(
             ^
3 errors generated.
Target //src/nginx/main:nginx-esp failed to build
```

Upon investigation, all `length` arguments were explicitly typed as `uint64_t` but were being passed to `EncodesGrpcCustomTrailers`, `EncodesGrpcMessage` and `EncodesGrpcStatusCode` that used `size_t`.  Unfortunately, `size_t` is not guaranteed to be the same size as `uint64_t` and the compilation error occured.  This commit updates the `length` arguments for `EncodesGrpcCustomTrailers`, `EncodesGrpcMessage` and `EncodesGrpcStatusCode` to be `uint64_t` instead of `size_t`.