### PR TITLE
Fix grpc stream memory leak by re-cycle buffers

### DIFF
--- a/src/nginx/grpc_passthrough_server_call.h
+++ b/src/nginx/grpc_passthrough_server_call.h
@@ -76,7 +76,7 @@ class NgxEspGrpcPassThroughServerCall : public NgxEspGrpcServerCall {
   // NgxEspGrpcServerCall implementation
   virtual bool ConvertRequestBody(std::vector<grpc_slice>* out);
   virtual bool ConvertResponseMessage(const ::grpc::ByteBuffer& msg,
-                                      ngx_chain_t* out);
+                                      ngx_chain_t** out);
 };
 
 }  // namespace nginx

--- a/src/nginx/grpc_server_call.cc
+++ b/src/nginx/grpc_server_call.cc
@@ -759,6 +759,9 @@ void NgxEspGrpcServerCall::Write(const ::grpc::ByteBuffer &msg,
 
   ngx_int_t rc = ngx_esp_write_output(
       r_, out, &NgxEspGrpcServerCall::OnDownstreamWriteable);
+  // Completely written buffers are added to the free list so they can be
+  // re-used by AllocNgxBufChain(). They could be used by next respond
+  // messages for passthrough grpc.
   ngx_chain_update_chains(r_->pool, &buf_free_, &buf_busy_, &out, buf_tag_);
 
   if (rc == NGX_OK) {

--- a/src/nginx/transcoded_grpc_server_call.cc
+++ b/src/nginx/transcoded_grpc_server_call.cc
@@ -146,15 +146,17 @@ void NgxEspTranscodedGrpcServerCall::Finish(
   // Finish the Transcoder input response stream and read the translated
   // response output.
   grpc_response_stream_->Finish();
-  ngx_chain_t out;
+  ngx_chain_t *out = nullptr;
   if (!ReadTranslatedResponse(&out)) {
     return;
   }
   // Mark this as the last buffer in the request
-  out.buf->last_buf = 1;
+  if (out) {
+    out->buf->last_buf = 1;
+  }
 
   // Send the final buffer and finalize the request
-  ngx_int_t rc = ngx_http_output_filter(r_, &out);
+  ngx_int_t rc = ngx_http_output_filter(r_, out);
   if (rc == NGX_ERROR) {
     ngx_log_error(NGX_LOG_DEBUG, r_->connection->log, 0,
                   "Failed to send the last buffer - rc=%d", rc);
@@ -192,7 +194,7 @@ bool NgxEspTranscodedGrpcServerCall::ConvertRequestBody(
 }
 
 bool NgxEspTranscodedGrpcServerCall::ConvertResponseMessage(
-    const ::grpc::ByteBuffer &msg, ngx_chain_t *out) {
+    const ::grpc::ByteBuffer &msg, ngx_chain_t **out) {
   // Serialize ::grpc::ByteBuffer into grpc_byte_buffer
   grpc_byte_buffer *grpc_msg = ConvertByteBuffer(msg);
   if (!grpc_msg) {
@@ -208,15 +210,20 @@ bool NgxEspTranscodedGrpcServerCall::ConvertResponseMessage(
   return ReadTranslatedResponse(out);
 }
 
-bool NgxEspTranscodedGrpcServerCall::ReadTranslatedResponse(ngx_chain_t *out) {
+bool NgxEspTranscodedGrpcServerCall::ReadTranslatedResponse(ngx_chain_t **out) {
   // Allocate an ngx_buf.
   ngx_buf_t *buf = reinterpret_cast<ngx_buf_t *>(ngx_calloc_buf(r_->pool));
-  if (!buf) {
+  ngx_chain_t *cl = reinterpret_cast<ngx_chain_t *>(
+      ngx_palloc(r_->pool, sizeof(ngx_chain_t)));
+  if (!buf || !cl) {
     ngx_log_error(NGX_LOG_ERR, r_->connection->log, 0,
                   "Failed to allocate response buffer header for GRPC "
                   "response message.");
     return false;
   }
+  cl->buf = buf;
+  *out = cl;
+  cl->next = nullptr;
 
   // Read the translated response into an ngx_buf.
   const void *buffer = nullptr;
@@ -232,16 +239,15 @@ bool NgxEspTranscodedGrpcServerCall::ReadTranslatedResponse(ngx_chain_t *out) {
     buf->pos = buf->start;
     buf->last = buf->pos + size;
     buf->temporary = 1;
+
   } else if (!transcoder_->ResponseStatus().ok()) {
     HandleError(utils::Status::FromProto(transcoder_->ResponseStatus()));
     return false;
   }
-  // If the transcoder doesn't return any data, we will return an empty ngx_buf
 
+  // If the transcoder doesn't return any data.
   buf->last_in_chain = 1;
   buf->flush = 1;
-  out->next = nullptr;
-  out->buf = buf;
 
   return true;
 }

--- a/src/nginx/transcoded_grpc_server_call.cc
+++ b/src/nginx/transcoded_grpc_server_call.cc
@@ -245,7 +245,7 @@ bool NgxEspTranscodedGrpcServerCall::ReadTranslatedResponse(ngx_chain_t **out) {
     return false;
   }
 
-  // If the transcoder doesn't return any data.
+  // If the transcoder doesn't return any data, we will return an empty ngx_buf
   buf->last_in_chain = 1;
   buf->flush = 1;
 

--- a/src/nginx/transcoded_grpc_server_call.h
+++ b/src/nginx/transcoded_grpc_server_call.h
@@ -70,7 +70,7 @@ class NgxEspTranscodedGrpcServerCall : public NgxEspGrpcServerCall {
   // NgxEspGrpcServerCall implementation
   virtual bool ConvertRequestBody(std::vector<grpc_slice>* out);
   virtual bool ConvertResponseMessage(const ::grpc::ByteBuffer& msg,
-                                      ngx_chain_t* out);
+                                      ngx_chain_t** out);
   virtual const ngx_str_t& response_content_type() const;
 
   // Constructor
@@ -82,7 +82,7 @@ class NgxEspTranscodedGrpcServerCall : public NgxEspGrpcServerCall {
 
   // Read the translated response message from the transcoder into an
   // ngx_chain_t.
-  bool ReadTranslatedResponse(ngx_chain_t* out);
+  bool ReadTranslatedResponse(ngx_chain_t** out);
 
   // Handle transcoding error
   void HandleError(const utils::Status& error);


### PR DESCRIPTION
This is to fix https://github.com/cloudendpoints/esp/issues/550

Create a free buffer list for re-cycle.  After a response buffer is written, the buffers are put into the free list in line 762, file src/nginx/grpc_server_call.cc

We keep re-using the largest buffer, if a buffer is too small, create a new one with a bigger size.

But only grpc pass through is using the buffer from re-cycle list since it may be long live streaming.
Transcoding buffer usage is different, and complicated. Beside it only has request/response, so its buffer usage is fine, not need to recycle it. 

