### PR TITLE
Exception fixes in serverless startup script

### DIFF
--- a/docker/serverless/env-start-esp.py
+++ b/docker/serverless/env-start-esp.py
@@ -27,12 +27,8 @@
 ###############################################################################
 #
 
+from __future__ import print_function
 import os
-
-CMD = "/usr/sbin/start_esp"
-
-# The command being run must be the 0th arg.
-ARGS = [CMD, "--enable_backend_routing"]
 
 
 def assert_env_var(name):
@@ -42,41 +38,72 @@ def assert_env_var(name):
         )
 
 
-assert_env_var("PORT")
-ARGS.append("--http_port={}".format(os.environ["PORT"]))
+def make_error_app(error_msg):
+    # error_msg must be a utf-8 or ascii bytestring
+    def error_app(environ, start_response):
+        start_response("503 Service Unavailable", [("Content-Type", "text/plain")])
+        return [error_msg, "\n"]
 
-assert_env_var("ENDPOINTS_SERVICE_NAME")
-ARGS.append("--service={}".format(os.environ["ENDPOINTS_SERVICE_NAME"]))
-
-if "ENDPOINTS_SERVICE_VERSION" in os.environ:
-    ARGS.extend(
-        [
-            "--rollout_strategy=fixed",
-            "--version={}".format(os.environ["ENDPOINTS_SERVICE_VERSION"]),
-        ]
-    )
-else:
-    ARGS.append("--rollout_strategy=managed")
-
-if "CORS_PRESET" in os.environ:
-    ARGS.append("--cors_preset={}".format(os.environ["CORS_PRESET"]))
-
-if "ESP_ARGS" in os.environ:
-    # By default, ESP_ARGS is comma-separated.
-    # But if a comma needs to appear within an arg, there is an alternative
-    # syntax: Pick a replacement delimiter, specify it at the beginning of the
-    # string between two caret (^) symbols, and use it within the arg string.
-    # Example:
-    # ^++^--cors_allow_methods="GET,POST,PUT,OPTIONS"++--cors_allow_credentials
-    arg_value = os.environ["ESP_ARGS"]
-
-    delim = ","
-    if arg_value.startswith("^") and "^" in arg_value[1:]:
-        delim, arg_value = arg_value[1:].split("^", 1)
-    if not delim:
-        raise ValueError("Malformed ESP_ARGS environment variable.")
-
-    ARGS.extend(arg_value.split(delim))
+    return error_app
 
 
-os.execv(CMD, ARGS)
+def serve_error_msg(error_msg):
+    print("Serving error handler with '{}'.".format(error_msg))
+    import wsgiref.simple_server
+
+    app = make_error_app(error_msg)
+    port = int(os.environ["PORT"])
+    server = wsgiref.simple_server.make_server("", port, app)
+    server.serve_forever()
+
+
+def main():
+    CMD = "/usr/sbin/start_esp"
+
+    # The command being run must be the 0th arg.
+    ARGS = [CMD, "--enable_backend_routing"]
+
+    assert_env_var("PORT")
+    ARGS.append("--http_port={}".format(os.environ["PORT"]))
+
+    try:
+        assert_env_var("ENDPOINTS_SERVICE_NAME")
+    except KeyError as error:
+        serve_error_msg(error.message)
+    ARGS.append("--service={}".format(os.environ["ENDPOINTS_SERVICE_NAME"]))
+
+    if "ENDPOINTS_SERVICE_VERSION" in os.environ:
+        ARGS.extend(
+            [
+                "--rollout_strategy=fixed",
+                "--version={}".format(os.environ["ENDPOINTS_SERVICE_VERSION"]),
+            ]
+        )
+    else:
+        ARGS.append("--rollout_strategy=managed")
+
+    if "CORS_PRESET" in os.environ:
+        ARGS.append("--cors_preset={}".format(os.environ["CORS_PRESET"]))
+
+    if "ESP_ARGS" in os.environ:
+        # By default, ESP_ARGS is comma-separated.
+        # But if a comma needs to appear within an arg, there is an alternative
+        # syntax: Pick a replacement delimiter, specify it at the beginning of the
+        # string between two caret (^) symbols, and use it within the arg string.
+        # Example:
+        # ^++^--cors_allow_methods="GET,POST,PUT,OPTIONS"++--cors_allow_credentials
+        arg_value = os.environ["ESP_ARGS"]
+
+        delim = ","
+        if arg_value.startswith("^") and "^" in arg_value[1:]:
+            delim, arg_value = arg_value[1:].split("^", 1)
+        if not delim:
+            serve_error_msg("Malformed ESP_ARGS environment variable.")
+
+        ARGS.extend(arg_value.split(delim))
+
+    os.execv(CMD, ARGS)
+
+
+if __name__ == "__main__":
+    main()

--- a/docker/serverless/env-start-esp.py
+++ b/docker/serverless/env-start-esp.py
@@ -37,7 +37,7 @@ ARGS = [CMD, "--enable_backend_routing"]
 
 def assert_env_var(name):
     if name not in os.environ:
-        raise ApplicationError(
+        raise KeyError(
             "Serverless ESP expects {} in environment variables.".format(name)
         )
 
@@ -74,7 +74,7 @@ if "ESP_ARGS" in os.environ:
     if arg_value.startswith("^") and "^" in arg_value[1:]:
         delim, arg_value = arg_value[1:].split("^", 1)
     if not delim:
-        raise ApplicationError("Malformed ESP_ARGS environment variable.")
+        raise ValueError("Malformed ESP_ARGS environment variable.")
 
     ARGS.extend(arg_value.split(delim))
 

--- a/docker/serverless/env-start-esp.py
+++ b/docker/serverless/env-start-esp.py
@@ -63,6 +63,7 @@ def main():
     # The command being run must be the 0th arg.
     ARGS = [CMD, "--enable_backend_routing"]
 
+    # Uncaught KeyError; if no port, we can't serve a nice error handler. Crash instead.
     assert_env_var("PORT")
     ARGS.append("--http_port={}".format(os.environ["PORT"]))
 


### PR DESCRIPTION
When possible, start a simple HTTP server to serve 503 Service Unavailable with the error message.