### PR TITLE
Fix a crash from fuzz tests

### DIFF
--- a/script/linux-grpc-test-long-run
+++ b/script/linux-grpc-test-long-run
@@ -220,4 +220,4 @@ detect_memory_leak_final && MEMORY_LEAK=0 || MEMORY_LEAK=1
 # This is to be consistent with other http stress tests.
 # All failure will be analyzed by release-engineers.
 
-exit $((${GRPC_STRESS_FAILURES} + ${MEMORY_LEAK}))
+exit $((${GRPC_STRESS_FAILURES} + ${HTTP_STRESS_FAILURES} + ${MEMORY_LEAK}))

--- a/src/nginx/grpc_server_call.cc
+++ b/src/nginx/grpc_server_call.cc
@@ -225,6 +225,9 @@ void NgxEspGrpcServerCall::UpdateResponseMessageStat(int64_t size) {
 
 void NgxEspGrpcServerCall::SetGrpcUpstreamCancel(
     std::function<void()> grpc_upstream_cancel) {
+  if (!cln_.data) {
+    return;
+  }
   ngx_esp_request_ctx_t *ctx = ngx_http_esp_ensure_module_ctx(r_);
   ctx->grpc_upstream_cancel =
       std::unique_ptr<std::function<void()>>(new auto(grpc_upstream_cancel));


### PR DESCRIPTION
In some error cases,  request r could be gone before grpc server_call is deleted by grpc proxy_flow.

Also check http stream failure in e2e tests.  That is why this crash was not detected by e2e tests.