### PR TITLE
tests: make tests run on macOS/OS X

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -47,7 +47,6 @@ build --cxxopt -Wnon-virtual-dtor
 build --cxxopt -Wformat
 build --cxxopt -Wformat-security
 
-
 fetch --incompatible_remove_native_git_repository=false
 fetch --incompatible_remove_native_http_archive=false
 fetch --incompatible_package_name_is_a_function=false
@@ -55,3 +54,11 @@ fetch --incompatible_package_name_is_a_function=false
 build --incompatible_remove_native_git_repository=false
 build --incompatible_remove_native_http_archive=false
 build --incompatible_package_name_is_a_function=false
+
+# When building gRPC on a Mac, "-DGRPC_BAZEL_BUILD" is required due to
+# https://github.com/bazelbuild/bazel/issues/4341
+# (Also found in the gRPC .bazelrc)
+build --per_file_copt="external/com_github_grpc_grpc/.*@-DGRPC_BAZEL_BUILD"
+
+# Required for nginx tests (Also found in Jenkinsfile)
+build --action_env=PERL5LIB=.

--- a/src/nginx/t/ApiManager.pm
+++ b/src/nginx/t/ApiManager.pm
@@ -34,6 +34,7 @@ use warnings;
 
 package ApiManager;
 
+use Config;
 use FindBin;
 use IO::Socket;
 use JSON::PP;
@@ -328,9 +329,9 @@ sub grpc_test_server {
 
 sub grpc_interop_server {
   my ($t, $port) = @_;
-  my $server = './external/org_golang_google_grpc/interop/server/linux_amd64_stripped/server';
+  my $server = "./external/org_golang_google_grpc/interop/server/$Config{osname}_amd64_stripped/server";
   unless (-e $server) {
-    $server = './external/org_golang_google_grpc/interop/server/linux_amd64/server';
+    $server = "./external/org_golang_google_grpc/interop/server/$Config{osname}_amd64/server";
   }
   exec $server, "--port", $port;
 }
@@ -376,9 +377,9 @@ sub run_grpc_test {
 sub run_grpc_interop_test {
   my ($t, $port, $test_case, @args) = @_;
   my $testdir = $t->testdir();
-  my $client = './test/grpc/linux_amd64_stripped/interop-client';
+  my $client = "./test/grpc/$Config{osname}_amd64_stripped/interop-client";
   unless (-e $client) {
-    $client = './test/grpc/linux_amd64/interop-client';
+    $client = "./test/grpc/$Config{osname}_amd64/interop-client";
   }
   return system "$client --server_port $port --test_case $test_case " . join(' ', @args)
 }


### PR DESCRIPTION
When attempting to run the unit tests on macOS/OS X, the build process would typically fail due to something like this:

```
ERROR: /private/var/tmp/_bazel_notyou/78403766dcde049347f91d5e087e2902/external/com_github_grpc_grpc/BUILD:1556:1: Linking of rule '@com_github_grpc_grpc//:grpc_transport_chttp2' failed (Exit 1).
13ld: illegal thread local variable reference to regular symbol __ZN9grpc_core7ExecCtx9exec_ctx_E for architecture x86_64
14clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Basically, the issue is caused by a [Bazel bug](https://github.com/bazelbuild/bazel/issues/4341) and the [workaround(https://github.com/grpc/grpc/pull/13929) was to define `GRPC_BAZEL_BUILD` when building gRPC.

Once the tests would build, they would run and fail due to two issues:

1. When running the nginx tests, we need to set `PERL5LIB=.`, something that is present in the `Jenkinsfile`
2. There were hard-coded paths in `src/nginx/t/ApiManager.pm` that were specific to Linux

Once these three issues were resolved, you can run `bazel test -c opt //src/... //third_party:all` on a Mac and all tests build, run and pass.

**Caveat**

One test fails on macOS/OS X but it's unrelated to these changes:

```
Executing tests from //src/grpc:zero_copy_stream_test
-----------------------------------------------------------------------------
Running main() from gmock_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from GrpcZeroCopyInputStreamTest
[ RUN      ] GrpcZeroCopyInputStreamTest.SimpleRead
E0302 18:43:11.650385000 140736178963328 tls_pthread.cc:26]            assertion failed: 0 == pthread_setspecific(tls->key, (void*)value)
Abort trap: 6
```