### PR TITLE
Fix grpc_backend_ssl server_config format

### DIFF
--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -38,6 +38,18 @@ cc_binary(
 )
 
 cc_binary(
+    name = "read_server_config",
+    srcs = [
+        "read_server_config.cc",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/api_manager:server_config_proto",
+        "//src/api_manager/utils",
+    ],
+)
+
+cc_binary(
     name = "auth_token_gen",
     srcs = [
         "auth_token_gen.cc",

--- a/src/tools/read_server_config.cc
+++ b/src/tools/read_server_config.cc
@@ -31,7 +31,8 @@
 #include "src/api_manager/proto/server_config.pb.h"
 #include "src/api_manager/utils/marshalling.h"
 
-bool ParseConfig(std::istream &src, ::google::api_manager::proto::ServerConfig *service) {
+bool ParseConfig(std::istream &src,
+                 ::google::api_manager::proto::ServerConfig *service) {
   ::google::protobuf::TextFormat::Parser parser;
 
   std::string contents;
@@ -65,7 +66,7 @@ bool ParseConfig(std::istream &src, ::google::api_manager::proto::ServerConfig *
 
 int main(int argc, char **argv) {
   if (argc < 2) {
-    std::cerr  << "Usage: " << argv[0] << " file" << std::endl;
+    std::cerr << "Usage: " << argv[0] << " file" << std::endl;
     return 1;
   }
   const char *src_path = argv[1];
@@ -74,7 +75,8 @@ int main(int argc, char **argv) {
 
   ::google::api_manager::proto::ServerConfig config;
   if (!ParseConfig(src, &config)) {
-    std::cerr << "ERROR: Cannot parse server_config from " << src_path << std::endl;
+    std::cerr << "ERROR: Cannot parse server_config from " << src_path
+              << std::endl;
     return 1;
   }
 

--- a/src/tools/read_server_config.cc
+++ b/src/tools/read_server_config.cc
@@ -1,0 +1,82 @@
+// Copyright (C) Extensible Service Proxy Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+#include <fstream>
+#include <iostream>
+
+#include "google/protobuf/text_format.h"
+#include "src/api_manager/proto/server_config.pb.h"
+#include "src/api_manager/utils/marshalling.h"
+
+bool ParseConfig(std::istream &src, ::google::api_manager::proto::ServerConfig *service) {
+  ::google::protobuf::TextFormat::Parser parser;
+
+  std::string contents;
+  src.seekg(0, std::ios::end);
+  contents.reserve(src.tellg());
+  src.seekg(0, std::ios::beg);
+  contents.assign((std::istreambuf_iterator<char>(src)),
+                  (std::istreambuf_iterator<char>()));
+
+  // Try JSON.
+  ::google::api_manager::utils::Status status =
+      ::google::api_manager::utils::JsonToProto(contents, service);
+  if (status.ok()) {
+    return true;
+  }
+
+  // Try binary.
+  service->Clear();
+  if (service->ParseFromString(contents)) {
+    return true;
+  }
+
+  // Try text format.
+  service->Clear();
+  if (::google::protobuf::TextFormat::ParseFromString(contents, service)) {
+    return true;
+  }
+
+  return false;
+}
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::cerr  << "Usage: " << argv[0] << " file" << std::endl;
+    return 1;
+  }
+  const char *src_path = argv[1];
+  std::ifstream src;
+  src.open(src_path, std::ifstream::in | std::ifstream::binary);
+
+  ::google::api_manager::proto::ServerConfig config;
+  if (!ParseConfig(src, &config)) {
+    std::cerr << "ERROR: Cannot parse server_config from " << src_path << std::endl;
+    return 1;
+  }
+
+  return 0;
+}

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -316,11 +316,11 @@ def generate_grpc_backend_ssl_credentials(args):
       return None
     out_str = "  use_ssl: true"
     if args.grpc_backend_ssl_root_certs_file:
-      out_str += "\n  root_certs_file: " + args.grpc_backend_ssl_root_certs_file
+      out_str += "\n  root_certs_file: \"{}\"".format(args.grpc_backend_ssl_root_certs_file)
     if args.grpc_backend_ssl_private_key_file:
-      out_str += "\n  private_key_file: " + args.grpc_backend_ssl_private_key_file
+      out_str += "\n  private_key_file: \"{}\"".format(args.grpc_backend_ssl_private_key_file)
     if args.grpc_backend_ssl_cert_chain_file:
-      out_str += "\n  cert_chain_file: " + args.grpc_backend_ssl_cert_chain_file
+      out_str += "\n  cert_chain_file: \"{}\"".format(args.grpc_backend_ssl_cert_chain_file)
     return out_str
 
 def fetch_service_config(args):

--- a/start_esp/test/BUILD
+++ b/start_esp/test/BUILD
@@ -59,5 +59,6 @@ py_test(
         ":nginx-conf-template",
         ":server-conf-template",
         ":start_esp_binary",
+        "//src/tools:read_server_config",
     ] + glob(["testdata/*"]),
 )

--- a/start_esp/test/start_esp_test.py
+++ b/start_esp/test/start_esp_test.py
@@ -44,6 +44,7 @@ class TestStartEsp(unittest.TestCase):
     empty_flag_config_generator = "./start_esp/test/start_esp_binary --generate_config_file_only --server_config_generation_path ./start_esp/test/generated_server_configuration.json"
     basic_config_generator = "./start_esp/test/start_esp_binary --generate_config_file_only --pid_file ./start_esp/test/pid_file --service_account_key key --config_dir ./start_esp/test --template ./start_esp/test/nginx-conf-template --server_config_template ./start_esp/test/server-conf-template --service_json_path ./start_esp/test/testdata/test_service_config_1.json --server_config_generation_path ./start_esp/test/generated_server_configuration.json"
     backend_routing_config_generator = "./start_esp/test/start_esp_binary --enable_backend_routing --generate_config_file_only --pid_file ./start_esp/test/pid_file --service_account_key key --config_dir ./start_esp/test --template ./start_esp/test/nginx-conf-template --server_config_template ./start_esp/test/server-conf-template --service_json_path ./start_esp/test/testdata/test_service_config_1.json --server_config_generation_path ./start_esp/test/generated_server_configuration.json"
+    read_server_config = "./src/tools/read_server_config "
 
     @staticmethod
     def file_equal(path1, path2):
@@ -66,6 +67,8 @@ class TestStartEsp(unittest.TestCase):
         self.assertTrue(os.path.isfile(expected_config_file), "the expected config file does not exist")
         self.assertTrue(os.path.isfile(self.nginx_conf_template), "the template config file does not exist")
         os.system(config_generator)
+        self.assertTrue((os.system(self.read_server_config + self.generated_server_config_file) == 0),
+                        "generate invalid server config format.")
         self.assertTrue(os.path.isfile(generated_config_file), "the config file is not generated")
         is_equal = TestStartEsp.file_equal(generated_config_file, expected_config_file)
         if not is_equal :

--- a/start_esp/test/testdata/expected_grpc_backend_ssl_client_key_server.json
+++ b/start_esp/test/testdata/expected_grpc_backend_ssl_client_key_server.json
@@ -39,7 +39,7 @@ experimental {
 rollout_strategy: "None"
 grpc_backend_ssl_credentials: {
   use_ssl: true
-  root_certs_file: /etc/nginx/trusted-ca-certificates.crt
-  private_key_file: /etc/nginx/client.key
-  cert_chain_file: /etc/nginx/client.crt
+  root_certs_file: "/etc/nginx/trusted-ca-certificates.crt"
+  private_key_file: "/etc/nginx/client.key"
+  cert_chain_file: "/etc/nginx/client.crt"
 }

--- a/start_esp/test/testdata/expected_grpc_backend_ssl_enable_server.json
+++ b/start_esp/test/testdata/expected_grpc_backend_ssl_enable_server.json
@@ -39,5 +39,5 @@ experimental {
 rollout_strategy: "None"
 grpc_backend_ssl_credentials: {
   use_ssl: true
-  root_certs_file: /etc/nginx/trusted-ca-certificates.crt
+  root_certs_file: "/etc/nginx/trusted-ca-certificates.crt"
 }

--- a/start_esp/test/testdata/expected_grpc_backend_ssl_root_certs_server.json
+++ b/start_esp/test/testdata/expected_grpc_backend_ssl_root_certs_server.json
@@ -39,5 +39,5 @@ experimental {
 rollout_strategy: "None"
 grpc_backend_ssl_credentials: {
   use_ssl: true
-  root_certs_file: /etc/nginx/custom-root-ca.cert
+  root_certs_file: "/etc/nginx/custom-root-ca.cert"
 }


### PR DESCRIPTION
Added a c++ program to read the server_config json file generated by start_esp, to make sure the json format can be converted to server_config proto.