### PR TITLE
Percent encode for grpc tailer: grpc-message

### DIFF
--- a/src/nginx/grpc_finish.cc
+++ b/src/nginx/grpc_finish.cc
@@ -108,7 +108,8 @@ ngx_int_t GrpcFinish(
   // Status-Message
   if (!status.ok()) {
     ngx_str_t message;
-    if (ngx_str_copy_from_std(r->pool, status.message(), &message) != NGX_OK) {
+    if (ngx_str_copy_from_std(r->pool, grpc_percent_encode(status.message()),
+                              &message) != NGX_OK) {
       ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,
                     "Failed to convert gRPC status message.");
       return NGX_DONE;

--- a/src/nginx/grpc_web_finish.cc
+++ b/src/nginx/grpc_web_finish.cc
@@ -25,6 +25,7 @@
  */
 
 #include "src/nginx/grpc_finish.h"
+#include "src/nginx/util.h"
 
 extern "C" {
 #include "src/http/ngx_http.h"
@@ -238,7 +239,8 @@ ngx_int_t GrpcWebFinish(
   // Encodes GRPC message.
   ngx_chain_t *grpc_message = nullptr;
   if (!status.message().empty()) {
-    grpc_message = EncodesGrpcMessage(r, status.message(), &length);
+    grpc_message =
+        EncodesGrpcMessage(r, grpc_percent_encode(status.message()), &length);
     RETURN_IF_NULL(r, grpc_message, NGX_DONE,
                    "Failed to encode gRPC-Web message.");
   }

--- a/src/nginx/t/grpc_interop_status.t
+++ b/src/nginx/t/grpc_interop_status.t
@@ -44,7 +44,7 @@ my $ServiceControlPort = ApiManager::pick_port();
 my $GrpcBackendPort = ApiManager::pick_port();
 my $HttpBackendPort = ApiManager::pick_port();
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(4);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(5);
 
 $t->write_file(
     'service.pb.txt',
@@ -86,6 +86,7 @@ is($t->waitforsocket("127.0.0.1:${Http2NginxPort}"), 1, 'Nginx socket ready.');
 ################################################################################
 my @test_cases = (
     'status_code_and_message',
+    'special_status_message',
 );
 
 foreach my $case (@test_cases) {

--- a/src/nginx/util.cc
+++ b/src/nginx/util.cc
@@ -24,7 +24,9 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 //
+
 #include "src/nginx/util.h"
+#include "src/core/lib/slice/percent_encoding.h"
 
 #include <cstdio>
 
@@ -227,6 +229,14 @@ ngx_esp_header_iterator ngx_esp_header_iterator::operator++(int) {
   ngx_esp_header_iterator it(*this);
   operator++();
   return it;
+}
+
+std::string grpc_percent_encode(const std::string &src) {
+  grpc_slice in = grpc_slice_from_static_buffer(src.data(), src.size());
+  grpc_slice out = grpc_percent_encode_slice(
+      in, &grpc_url_percent_encoding_unreserved_bytes[0]);
+  return std::string(reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(out)),
+                     GRPC_SLICE_LENGTH(out));
 }
 
 }  // namespace nginx

--- a/src/nginx/util.h
+++ b/src/nginx/util.h
@@ -79,6 +79,9 @@ ngx_table_elt_t *ngx_esp_find_headers_in(ngx_http_request_t *r, u_char *name,
 ngx_table_elt_t *ngx_esp_find_headers_out(ngx_http_request_t *r, u_char *name,
                                           size_t len);
 
+// Call grpc_percent_encode_slice to encode the data
+std::string grpc_percent_encode(const std::string &data);
+
 // An InputIterator for nginx headers.
 class ngx_esp_header_iterator {
  public:

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -67,8 +67,10 @@ cc_binary(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//external:absl_strings",
         "//external:api_manager",
         "//external:servicecontrol",
+        "@com_github_grpc_grpc//src/proto/grpc/testing:messages_proto",
     ],
 )
 

--- a/test/grpc/interop-client.go
+++ b/test/grpc/interop-client.go
@@ -34,7 +34,7 @@ import (
 	"net"
 	"strconv"
 
-  "golang.org/x/net/context"
+	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/oauth"
@@ -83,10 +83,11 @@ var (
         cancel_after_begin: cancellation after metadata has been sent but before payloads are sent;
         cancel_after_first_response: cancellation after receiving 1st message from the server;
         status_code_and_message: status code propagated back to client;
+        special_status_message: Unicode and whitespace is correctly processed in status message;
         custom_metadata: server will echo custom metadata;
         unimplemented_method: client attempts to call unimplemented method;
         unimplemented_service: client attempts to call unimplemented service.`)
-	apiKey                = flag.String("api_key", "", "API key")
+	apiKey = flag.String("api_key", "", "API key")
 	// The test CA root cert file
 	testCAFile = "testdata/ca.pem"
 )
@@ -199,6 +200,9 @@ func main() {
 	case "status_code_and_message":
 		interop.DoStatusCodeAndMessage(tc)
 		grpclog.Println("StatusCodeAndMessage done")
+	case "special_status_message":
+		interop.DoSpecialStatusMessage(tc)
+		grpclog.Infoln("SpecialStatusMessage done")
 	case "custom_metadata":
 		interop.DoCustomMetadata(tc)
 		grpclog.Println("CustomMetadata done")


### PR DESCRIPTION
* call grpc internal function grpc_percent_encode
* add special_status_message test case for grpc interop test
* polish grpc_web_interop "t" tests to be more readable.
* add a message with space, to make sure it is encoded with %20.
