### PR TITLE
Update Jenkins Image to debian-9 and use root instead of jenkins user.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ SUPPORTED_STAGES = [
 ]
 
 // Supported VM Images
-SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-8:0.12'
+SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-9:0.2'
 
 // Release Qualification end to end tests.
 // If RAPTURE_REPO build parameter is set only those test will run.
@@ -210,7 +210,7 @@ def presubmit() {
   def branches = [
       'asan': {
         BuildNode {
-          presubmitTests('asan')           
+          presubmitTests('asan')
         }
       },
       'build-and-test': {
@@ -228,7 +228,7 @@ def presubmit() {
         BuildNode {
           //Temporarily disable the tsan presubmit tests
           //as a workaround before the Jenkins problem is resolved.
-          //To-do: enable the tsan presubmit tests after 
+          //To-do: enable the tsan presubmit tests after
           //the Jenkins problem is resolved.
           //presubmitTests('tsan')
         }
@@ -874,9 +874,9 @@ def initialize() {
 }
 
 def DefaultNode(Closure body) {
-  podTemplate(label: 'debian-8-pod', cloud: 'kubernetes', containers: [
+  podTemplate(label: 'debian-9-pod', cloud: 'kubernetes', containers: [
       containerTemplate(
-          name: 'debian-8',
+          name: 'debian-9',
           image: SLAVE_IMAGE,
           args: 'cat',
           ttyEnabled: true,
@@ -888,10 +888,10 @@ def DefaultNode(Closure body) {
           resourceRequestMemory: '4Gi',
           resourceLimitMemory: '64Gi',
           envVars: [
-              envVar(key: 'PLATFORM', value: 'debian-8')
+              envVar(key: 'PLATFORM', value: 'debian-9')
           ])]) {
-    node('debian-8-pod') {
-      container('debian-8') {
+    node('debian-9-pod') {
+      container('debian-9') {
         body()
       }
     }
@@ -899,9 +899,9 @@ def DefaultNode(Closure body) {
 }
 
 def BuildNode(Closure body) {
-  podTemplate(label: 'debian-8-pod', cloud: 'kubernetes', containers: [
+  podTemplate(label: 'debian-9-pod', cloud: 'kubernetes', containers: [
       containerTemplate(
-          name: 'debian-8',
+          name: 'debian-9',
           image: SLAVE_IMAGE,
           args: 'cat',
           ttyEnabled: true,
@@ -913,10 +913,10 @@ def BuildNode(Closure body) {
           resourceRequestMemory: '8Gi',
           resourceLimitMemory: '64Gi',
           envVars: [
-              envVar(key: 'PLATFORM', value: 'debian-8')
+              envVar(key: 'PLATFORM', value: 'debian-9')
           ])]) {
-    node('debian-8-pod') {
-      container('debian-8') {
+    node('debian-9-pod') {
+      container('debian-9') {
         body()
       }
     }

--- a/jenkins/slaves/Makefile
+++ b/jenkins/slaves/Makefile
@@ -1,17 +1,17 @@
 PROJECT = endpoints-jenkins
-VERSION = 0.12
+VERSION = 0.2
 TOOLS_BUCKET = endpoints-tools
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:
-	docker build -t debian-8 --build-arg TOOLS_BUCKET="${TOOLS_BUCKET}" -f debian-8.Dockerfile ../../
-	docker tag debian-8 gcr.io/$(PROJECT)/debian-8:$(VERSION)
-	docker tag debian-8 gcr.io/$(PROJECT)/debian-8:latest
+	docker build -t debian-9 --build-arg TOOLS_BUCKET="${TOOLS_BUCKET}" -f debian-9.Dockerfile ../../
+	docker tag debian-9 gcr.io/$(PROJECT)/debian-9:$(VERSION)
+	docker tag debian-9 gcr.io/$(PROJECT)/debian-9:latest
 
 
-push:
-	gcloud docker -- push gcr.io/$(PROJECT)/debian-8:$(VERSION)
-	gcloud docker -- push gcr.io/$(PROJECT)/debian-8:latest
+push: image
+	docker push gcr.io/$(PROJECT)/debian-9:$(VERSION)
+	docker push gcr.io/$(PROJECT)/debian-9:latest
 
 
 .PHONY: image push

--- a/jenkins/slaves/debian-9.Dockerfile
+++ b/jenkins/slaves/debian-9.Dockerfile
@@ -1,5 +1,5 @@
-# Stored at gcr.io/endpoints-jenkins/debian-8-slave:latest
-FROM debian:jessie-backports
+# Stored at gcr.io/endpoints-jenkins/debian-9-slave:latest
+FROM debian:stretch-backports
 
 # Docker version needs to match GKE (Docker Host)
 ENV DOCKER_VERSION 1.11.2
@@ -12,15 +12,11 @@ RUN rm -rf /var/lib/apt/lists/* \
     && apt-get install -qqy git iptables procps sudo xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Adding sudo group user no password access.
-# This is used by Jenkins user to start docker service
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
 # Installing Tools
 ADD script /tmp/esp_tmp/script
 RUN chmod +x /tmp/esp_tmp/script/linux-install-software
 RUN /tmp/esp_tmp/script/linux-install-software \
-      -p "debian-8" \
+      -p "debian-9" \
       -b "${TOOLS_BUCKET}" \
     && rm -rf /tmp/esp_tmp
 
@@ -28,11 +24,5 @@ ENV PATH /usr/lib/google-cloud-sdk/bin:${PATH}
 
 ADD jenkins/slaves/entrypoint /usr/local/bin/entrypoint
 RUN chmod +rx /usr/local/bin/entrypoint
-
-# Adding a Jenkins User
-ENV HOME /home/jenkins
-RUN groupadd -g 10000 jenkins
-RUN useradd -c "Jenkins user" -d ${HOME} -u 10000 -g 10000 -G docker,sudo -m jenkins -s /bin/bash
-USER jenkins
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/jenkins/slaves/entrypoint
+++ b/jenkins/slaves/entrypoint
@@ -26,8 +26,5 @@
 #
 ################################################################################
 #
-if [[ ${UID} -ne 0 ]]; then
-  SUDO=sudo
-fi
-${SUDO} service docker start
+service docker start
 exec "$@"

--- a/script/all-utilities
+++ b/script/all-utilities
@@ -31,7 +31,7 @@ if [[ $UID -ne 0 ]]; then
   SUDO=sudo
 fi
 
-[[ -z "${PLATFORM}" ]] && PLATFORM='debian-8'
+[[ -z "${PLATFORM}" ]] && PLATFORM='debian-9'
 TOOLS_DIR='/tmp/esp-tools'
 
 # Library of useful utilities.

--- a/script/linux-install-software
+++ b/script/linux-install-software
@@ -55,7 +55,7 @@ function install_packages() {
     autotools-dev \
     ca-certificates \
     curl \
-    ca-certificates-java=20161107~bpo8+1 \
+    ca-certificates-java \
     g++ \
     gcc \
     gettext \

--- a/script/tools/linux-install-docker
+++ b/script/tools/linux-install-docker
@@ -51,7 +51,7 @@ VERSION_SUFFIX="${JESSIE_VERSION_SUFFIX}"
 function set_platform_env() {
   local platform="${1}"
   case "${platform}" in
-    'debian-8')
+    'debian-9')
       REPO="${JESSIE_REPO}"
       VERSION_SUFFIX="${JESSIE_VERSION_SUFFIX}";;
     'ubuntu-16-04')


### PR DESCRIPTION
The issue is that we are running the node as the user jenkins (UID 10000). For some reason the node cannot have access to the directory created by the jnlp container. I am updating the docker image to run as root and no more as jenkins, as in my experience this creates confusion in k8s deployement.

Noticed that debian-8 was depreacted so had to use debian-9 instead to be able to build the image.