### PR TITLE
Fix Jenkins test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ SUPPORTED_STAGES = [
 ]
 
 // Supported VM Images
-SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-9:0.1'
+SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-9:0.6'
 
 // Release Qualification end to end tests.
 // If RAPTURE_REPO build parameter is set only those test will run.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ SUPPORTED_STAGES = [
 ]
 
 // Supported VM Images
-SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-8:0.12'
+SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-9:0.1'
 
 // Release Qualification end to end tests.
 // If RAPTURE_REPO build parameter is set only those test will run.
@@ -210,7 +210,7 @@ def presubmit() {
   def branches = [
       'asan': {
         BuildNode {
-          presubmitTests('asan')           
+          presubmitTests('asan')
         }
       },
       'build-and-test': {
@@ -228,7 +228,7 @@ def presubmit() {
         BuildNode {
           //Temporarily disable the tsan presubmit tests
           //as a workaround before the Jenkins problem is resolved.
-          //To-do: enable the tsan presubmit tests after 
+          //To-do: enable the tsan presubmit tests after
           //the Jenkins problem is resolved.
           //presubmitTests('tsan')
         }
@@ -808,7 +808,8 @@ def stashSourceCode() {
 }
 
 def checkoutSourceCode() {
-  deleteDir()
+  //Somehow failed to delete some files.
+  //deleteDir()
   echo('Unstashing source code')
   fastUnstash('src-code')
   sh("git diff")
@@ -874,9 +875,9 @@ def initialize() {
 }
 
 def DefaultNode(Closure body) {
-  podTemplate(label: 'debian-8-pod', cloud: 'kubernetes', containers: [
+  podTemplate(label: 'debian-9-pod', cloud: 'kubernetes', containers: [
       containerTemplate(
-          name: 'debian-8',
+          name: 'debian-9',
           image: SLAVE_IMAGE,
           args: 'cat',
           ttyEnabled: true,
@@ -888,10 +889,10 @@ def DefaultNode(Closure body) {
           resourceRequestMemory: '4Gi',
           resourceLimitMemory: '64Gi',
           envVars: [
-              envVar(key: 'PLATFORM', value: 'debian-8')
+              envVar(key: 'PLATFORM', value: 'debian-9')
           ])]) {
-    node('debian-8-pod') {
-      container('debian-8') {
+    node('debian-9-pod') {
+      container('debian-9') {
         body()
       }
     }
@@ -899,9 +900,9 @@ def DefaultNode(Closure body) {
 }
 
 def BuildNode(Closure body) {
-  podTemplate(label: 'debian-8-pod', cloud: 'kubernetes', containers: [
+  podTemplate(label: 'debian-9-pod', cloud: 'kubernetes', containers: [
       containerTemplate(
-          name: 'debian-8',
+          name: 'debian-9',
           image: SLAVE_IMAGE,
           args: 'cat',
           ttyEnabled: true,
@@ -913,10 +914,10 @@ def BuildNode(Closure body) {
           resourceRequestMemory: '8Gi',
           resourceLimitMemory: '64Gi',
           envVars: [
-              envVar(key: 'PLATFORM', value: 'debian-8')
+              envVar(key: 'PLATFORM', value: 'debian-9')
           ])]) {
-    node('debian-8-pod') {
-      container('debian-8') {
+    node('debian-9-pod') {
+      container('debian-9') {
         body()
       }
     }

--- a/jenkins/slaves/Makefile
+++ b/jenkins/slaves/Makefile
@@ -1,5 +1,5 @@
 PROJECT = endpoints-jenkins
-VERSION = 0.1
+VERSION = 0.6
 TOOLS_BUCKET = endpoints-tools
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./

--- a/jenkins/slaves/Makefile
+++ b/jenkins/slaves/Makefile
@@ -1,17 +1,17 @@
 PROJECT = endpoints-jenkins
-VERSION = 0.12
+VERSION = 0.1
 TOOLS_BUCKET = endpoints-tools
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./
 image:
-	docker build -t debian-8 --build-arg TOOLS_BUCKET="${TOOLS_BUCKET}" -f debian-8.Dockerfile ../../
-	docker tag debian-8 gcr.io/$(PROJECT)/debian-8:$(VERSION)
-	docker tag debian-8 gcr.io/$(PROJECT)/debian-8:latest
+	docker build -t debian-9 --build-arg TOOLS_BUCKET="${TOOLS_BUCKET}" -f debian-9.Dockerfile ../../
+	docker tag debian-9 gcr.io/$(PROJECT)/debian-9:$(VERSION)
+	docker tag debian-9 gcr.io/$(PROJECT)/debian-9:latest
 
 
-push:
-	gcloud docker -- push gcr.io/$(PROJECT)/debian-8:$(VERSION)
-	gcloud docker -- push gcr.io/$(PROJECT)/debian-8:latest
+push: image
+	docker push gcr.io/$(PROJECT)/debian-9:$(VERSION)
+	docker push gcr.io/$(PROJECT)/debian-9:latest
 
 
 .PHONY: image push

--- a/jenkins/slaves/debian-9.Dockerfile
+++ b/jenkins/slaves/debian-9.Dockerfile
@@ -1,8 +1,6 @@
-# Stored at gcr.io/endpoints-jenkins/debian-8-slave:latest
-FROM debian:jessie-backports
+# Stored at gcr.io/endpoints-jenkins/debian-9-slave:latest
+FROM debian:stretch-backports
 
-# Docker version needs to match GKE (Docker Host)
-ENV DOCKER_VERSION 1.11.2
 # Bucket used to store already built binaries
 ARG TOOLS_BUCKET
 
@@ -12,15 +10,11 @@ RUN rm -rf /var/lib/apt/lists/* \
     && apt-get install -qqy git iptables procps sudo xz-utils \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Adding sudo group user no password access.
-# This is used by Jenkins user to start docker service
-RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
-
 # Installing Tools
 ADD script /tmp/esp_tmp/script
 RUN chmod +x /tmp/esp_tmp/script/linux-install-software
 RUN /tmp/esp_tmp/script/linux-install-software \
-      -p "debian-8" \
+      -p "debian-9" \
       -b "${TOOLS_BUCKET}" \
     && rm -rf /tmp/esp_tmp
 
@@ -28,11 +22,5 @@ ENV PATH /usr/lib/google-cloud-sdk/bin:${PATH}
 
 ADD jenkins/slaves/entrypoint /usr/local/bin/entrypoint
 RUN chmod +rx /usr/local/bin/entrypoint
-
-# Adding a Jenkins User
-ENV HOME /home/jenkins
-RUN groupadd -g 10000 jenkins
-RUN useradd -c "Jenkins user" -d ${HOME} -u 10000 -g 10000 -G docker,sudo -m jenkins -s /bin/bash
-USER jenkins
 
 ENTRYPOINT ["/usr/local/bin/entrypoint"]

--- a/nginx.bzl
+++ b/nginx.bzl
@@ -54,6 +54,11 @@ def nginx_test(name, nginx, data=None, env=None, config=None, **kwargs):
   l = Label(nginx)
   env["TEST_PORT"] = "%s" % port
 
+  # This hack is required by Jenkins tests.
+  # Its slave container run as root, if nginx run as non-root
+  # it fails to open some temp files, all "t" tests will fail.
+  env["TEST_NGINX_GLOBALS"] = "user root;\n"
+
   env_files = {
       "TEST_NGINX_BINARY": "../__main__/" + l.package + "/" + l.name
   }

--- a/script/all-utilities
+++ b/script/all-utilities
@@ -31,7 +31,7 @@ if [[ $UID -ne 0 ]]; then
   SUDO=sudo
 fi
 
-[[ -z "${PLATFORM}" ]] && PLATFORM='debian-8'
+[[ -z "${PLATFORM}" ]] && PLATFORM='debian-9'
 TOOLS_DIR='/tmp/esp-tools'
 
 # Library of useful utilities.

--- a/script/linux-install-software
+++ b/script/linux-install-software
@@ -39,6 +39,7 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . ${DIR}/tools/linux-install-bazel || error_exit "Cannot load Bazel install script"
 . ${DIR}/tools/linux-install-docker || error_exit "Cannot load Docker install script"
 . ${DIR}/tools/linux-install-clang || error_exit "Cannot load Clang install script"
+. ${DIR}/tools/linux-install-gcc || error_exit "Cannot load gcc install script"
 . ${DIR}/tools/linux-install-gcloud || error_exit "Cannot load gcloud install script"
 . ${DIR}/tools/linux-install-wrk || error_exit "Cannot load wrk install script"
 . ${DIR}/tools/linux-install-nodejs || error_exit "Cannot load nodejs install script"
@@ -55,7 +56,7 @@ function install_packages() {
     autotools-dev \
     ca-certificates \
     curl \
-    ca-certificates-java=20161107~bpo8+1 \
+    ca-certificates-java \
     g++ \
     gcc \
     gettext \
@@ -102,6 +103,7 @@ retry install_packages || error_exit 'Cannot install required packages.'
 retry ${SUDO} pip install --upgrade python-gflags || error_exit 'Cannot install gflags.'
 retry ${SUDO} pip install --upgrade certifi || error_exit 'Cannot install certifi.'
 retry ${SUDO} pip install --upgrade oauth2client || error_exit 'Cannot install oauth2client.'
+retry ${SUDO} pip install --upgrade urllib3 || error_exit 'Cannot install urllib3.'
 retry ${SUDO} pip install --upgrade prettytable Mako pyaml dateutils || error_exit 'Cannot install prettytable Mako pyaml dateutils.'
 
 # Installing tools
@@ -112,9 +114,10 @@ else
   mkdir -p "${TOOLS_DIR}" -m 0777
 fi
 update_clang
+install_gcc
 update_gcloud
 update_bazel
-update_docker "${PLATFORM}"
+install_docker_for_debian9
 update_wrk
 update_node_js
 clear_apt

--- a/script/tools/linux-install-docker
+++ b/script/tools/linux-install-docker
@@ -36,7 +36,7 @@ fi
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
 
-DOCKER_VERSION='1.12.2'
+DOCKER_VERSION='18.09.5'
 
 # Ubuntu 16-04
 XENIAL_REPO='ubuntu-xenial'
@@ -51,7 +51,7 @@ VERSION_SUFFIX="${JESSIE_VERSION_SUFFIX}"
 function set_platform_env() {
   local platform="${1}"
   case "${platform}" in
-    'debian-8')
+    'debian-9')
       REPO="${JESSIE_REPO}"
       VERSION_SUFFIX="${JESSIE_VERSION_SUFFIX}";;
     'ubuntu-16-04')
@@ -82,6 +82,16 @@ function update_apt() {
   echo 'Adding repo for docker'
   echo "deb https://apt.dockerproject.org/repo ${REPO} main" \
     | ${SUDO} tee /etc/apt/sources.list.d/docker.list
+}
+
+# run as root
+function install_docker_for_debian9() {
+  apt update
+  apt -qqy install apt-transport-https ca-certificates curl gnupg2 software-properties-common
+  curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -
+  add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+  apt update
+  apt -qqy install docker-ce
 }
 
 function update_docker() {

--- a/script/tools/linux-install-gcc
+++ b/script/tools/linux-install-gcc
@@ -1,3 +1,5 @@
+#!/bin/bash
+#
 # Copyright (C) Extensible Service Proxy Authors
 # All rights reserved.
 #
@@ -24,39 +26,31 @@
 #
 ################################################################################
 #
-load("@io_bazel_rules_perl//perl:perl.bzl", "perl_library")
-load("//:nginx.bzl", "nginx_suite")
+# May require sudo login.
 
-perl_library(
-    name = "nginx_test",
-    srcs = glob([
-        "nginx-tests/lib/Test/**/*.pm",
-    ]),
-    visibility = ["//visibility:public"],
-)
+if [[ "$(uname)" != "Linux" ]]; then
+  echo "Run on Linux only."
+  exit 1
+fi
 
-# Nginx test suite containing all of the integration tests
-# included with Nginx.
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+. ${DIR}/all-utilities || { echo "Cannot load Bash utilities" ; exit 1 ; }
 
-nginx_suite(
-    nginx = "//src/nginx/main:nginx-esp",
-    tags = ["exclusive"],
-    tests = glob(
-        ["nginx-tests/*.t"],
-        exclude = [
-            # ssl.t, ssl_certificates.t, ssl_stapling are excluded from the
-            # test suite because boring ssl does not support renegotiation
-            # feature required by the test.
-            "nginx-tests/ssl.t",
-            "nginx-tests/ssl_certificates.t",
-            "nginx-tests/ssl_stapling.t",
-            # Jenkins tests require root so env(TEST_NGINX_GLOBALS) adds
-            # "user root;" in nginx.bzl. But this test also adds "user root;"
-            # so it fails. Just skip it for now.
-            "nginx-tests/proxy_bind_transparent.t",
-        ],
-    ),
-    deps = [
-        ":nginx_test",
-    ],
-)
+# asan tests only works for 4.9
+GCC_VERSION='4.9'
+
+function install_gcc() {
+  echo "Installing gcc-${GCC_VERSION}"
+  clear_apt
+  echo "deb http://ftp.us.debian.org/debian/ jessie main contrib non-free" >> /etc/apt/sources.list
+  echo "deb-src http://ftp.us.debian.org/debian/ jessie main contrib non-free" >> /etc/apt/sources.list
+  apt update
+  apt -y install g++-${GCC_VERSION}
+  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${GCC_VERSION} 1000
+  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${GCC_VERSION} 1000
+  update-alternatives --config gcc
+  update-alternatives --config g++
+  return 0
+}
+
+

--- a/test/grpc/Dockerfile.temp
+++ b/test/grpc/Dockerfile.temp
@@ -9,7 +9,7 @@
 # 4) docker build --no-cache -t "${IMAGE}" test/grpc
 # 5) gcloud docker -- push "${IMAGE}"
 
-FROM debian:jessie
+FROM debian:stretch-backports
 
 # Install all of the needed dependencies
 


### PR DESCRIPTION
Jenkin test is broken.  The root cause is detailed in https://github.com/cloudendpoints/esp/pull/589

In this change:
1) update the slave image to debian9 (debian8 is outdated and gone). and run it as root
2) fix "t" test failure due to "run as root",  always run nginx as root in "t" tests
3) update the instruction to install docker to debian9
4) install gcc-4.9 to debian9 in order to run asan
