### PR TITLE
Improve JWT verification error reporting

### DIFF
--- a/src/api_manager/auth/lib/BUILD
+++ b/src/api_manager/auth/lib/BUILD
@@ -33,6 +33,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//external:absl_strings",
         "//external:grpc",
         "//external:protobuf",
         "//include:headers_only",

--- a/src/api_manager/auth/lib/auth_jwt_validator_test.cc
+++ b/src/api_manager/auth/lib/auth_jwt_validator_test.cc
@@ -397,7 +397,7 @@ void TestTokenWithPubkey(char *token, const char *pkey) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(token, strlen(token));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   EXPECT_EQ(status.message(), "");
   EXPECT_EQ(kUserId, user_info.id);
   EXPECT_TRUE(user_info.audiences.end() != user_info.audiences.find(kAudience));
@@ -405,7 +405,7 @@ void TestTokenWithPubkey(char *token, const char *pkey) {
   EXPECT_EQ(kUserId, user_info.issuer);
 
   status = validator->VerifySignature(pkey, strlen(pkey));
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   EXPECT_EQ(status.message(), "");
 
   // Wrong length.
@@ -418,7 +418,7 @@ void TestTokenWithPubkey(char *token, const char *pkey) {
   // Wrong key length.
   validator = JwtValidator::Create(token, strlen(token));
   status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   status = validator->VerifySignature(pkey, strlen(pkey) - 1);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.message(), "Invalid JSON for public key")
@@ -427,7 +427,7 @@ void TestTokenWithPubkey(char *token, const char *pkey) {
   // Empty key.
   validator = JwtValidator::Create(token, strlen(token));
   status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   status = validator->VerifySignature("", 0);
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.message(), "Bad public key format: Public key is empty")
@@ -472,7 +472,7 @@ TEST_F(JwtValidatorTest, ParseToken) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(kTokenMultiAud, strlen(kTokenMultiAud));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   EXPECT_EQ(user_info.audiences.size(), 2U);
 
   // Token with only one dot.
@@ -553,7 +553,7 @@ TEST_F(JwtValidatorTest, WrongX509Key) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(token, strlen(token));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 
   status = validator->VerifySignature(kPublicKeyX509, strlen(kPublicKeyX509));
   EXPECT_FALSE(status.ok());
@@ -573,7 +573,7 @@ TEST_F(JwtValidatorTest, WrongJwkKey) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(token, strlen(token));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 
   status = validator->VerifySignature(kPublicKeyJwk, strlen(kPublicKeyJwk));
   EXPECT_FALSE(status.ok());
@@ -591,13 +591,13 @@ TEST_F(JwtValidatorTest, TokenWithAuthorizedParty) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(kTokenNoKid, strlen(kTokenNoKid));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   EXPECT_TRUE(user_info.authorized_party.empty());
 
   // Token with "azp" claim.
   validator = JwtValidator::Create(kTokenWithAzp, strlen(kTokenWithAzp));
   status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   EXPECT_EQ(user_info.authorized_party, kAuthorizedParty);
 }
 
@@ -606,7 +606,7 @@ TEST_F(JwtValidatorTest, ECX509PubKeyNotSupported) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(kTokenEC, strlen(kTokenEC));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
   status = validator->VerifySignature(kPublicKeyX509, strlen(kPublicKeyX509));
   EXPECT_FALSE(status.ok());
   EXPECT_EQ(status.message(), "Invalid public key: keys field is missing.")
@@ -625,7 +625,7 @@ TEST_F(JwtValidatorTest, WrongKeyEC) {
   std::unique_ptr<JwtValidator> validator =
       JwtValidator::Create(kTokenECWrongKey, strlen(kTokenECWrongKey));
   Status status = validator->Parse(&user_info);
-  EXPECT_TRUE(status.ok());
+  EXPECT_OK(status);
 
   status = validator->VerifySignature(kPublicKeyJwkEC, strlen(kPublicKeyJwkEC));
   EXPECT_FALSE(status.ok());

--- a/src/nginx/t/auth_no_pkey.t
+++ b/src/nginx/t/auth_no_pkey.t
@@ -120,7 +120,7 @@ like($response, qr/WWW-Authenticate: Bearer, error=\"invalid_token\"/, 'Return i
 like($response, qr/Content-Type: application\/json/i,
      'Invalid token returned application/json body');
 like($response, qr/JWT validation failed: Bad JWT format: Invalid JSON in header/i,
-		'JWT error text in the body.');
+     'JWT error text in the body.');
 
 my $bookstore_requests = $t->read_file('bookstore.log');
 is($bookstore_requests, '', 'Request did not reach the backend.');

--- a/src/nginx/t/auth_no_pkey.t
+++ b/src/nginx/t/auth_no_pkey.t
@@ -119,7 +119,8 @@ like($response, qr/HTTP\/1\.1 401 Unauthorized/, 'Returned HTTP 401, invalid tok
 like($response, qr/WWW-Authenticate: Bearer, error=\"invalid_token\"/, 'Return invalid_token challenge.');
 like($response, qr/Content-Type: application\/json/i,
      'Invalid token returned application/json body');
-like($response, qr/JWT validation failed: BAD_FORMAT/i, 'JWT error text in the body.');
+like($response, qr/JWT validation failed: Bad JWT format: Invalid JSON in header/i,
+		'JWT error text in the body.');
 
 my $bookstore_requests = $t->read_file('bookstore.log');
 is($bookstore_requests, '', 'Request did not reach the backend.');
@@ -143,9 +144,9 @@ my $expected_report_body = ServiceControl::gen_report_body({
   'response_code' => '401',
   'error_type' => '4xx',
   'request_size' => 75,
-  'response_size' => 371,
+  'response_size' => 399,
   'request_bytes' => 75,
-  'response_bytes' => 371,
+  'response_bytes' => 399,
   });
 
 ok(ServiceControl::compare_json($report_body, $expected_report_body), 'Report body was received.');

--- a/src/nginx/t/auth_pkey.t
+++ b/src/nginx/t/auth_pkey.t
@@ -113,7 +113,7 @@ foreach my $pkey($pkey_jwk, $pkey_x509) {
   like($response, qr/Content-Type: application\/json/i,
        'Missing creds returned application/json body.');
   like($response, qr/JWT validation failed: Missing or invalid credentials/i,
-       "Error body contains 'Missing or invalid credentials'.");
+                  "Error body contains 'Missing or invalid credentials'.");
 
   # Invalid credentials.
   $response = ApiManager::http($NginxPort,<<'EOF');
@@ -126,7 +126,8 @@ EOF
   like($response, qr/WWW-Authenticate: Bearer, error=\"invalid_token\"/, 'Returned invalid_token challenge.');
   like($response, qr/Content-Type: application\/json/i,
        'Invalid token returned application/json body.');
-  like($response, qr/JWT validation failed: BAD_FORMAT/i, "Error body contains 'invalid token'.");
+  like($response, qr/JWT validation failed: Bad JWT format: Invalid JSON in header/i,
+                  "Error body contains 'invalid token'.");
 
   # Token generated from different issuer/key.
   my $token = Auth::get_auth_token('./src/nginx/t/wrong-client-secret.json');

--- a/src/nginx/t/auth_pkey.t
+++ b/src/nginx/t/auth_pkey.t
@@ -113,7 +113,7 @@ foreach my $pkey($pkey_jwk, $pkey_x509) {
   like($response, qr/Content-Type: application\/json/i,
        'Missing creds returned application/json body.');
   like($response, qr/JWT validation failed: Missing or invalid credentials/i,
-                  "Error body contains 'Missing or invalid credentials'.");
+       "Error body contains 'Missing or invalid credentials'.");
 
   # Invalid credentials.
   $response = ApiManager::http($NginxPort,<<'EOF');
@@ -127,7 +127,7 @@ EOF
   like($response, qr/Content-Type: application\/json/i,
        'Invalid token returned application/json body.');
   like($response, qr/JWT validation failed: Bad JWT format: Invalid JSON in header/i,
-                  "Error body contains 'invalid token'.");
+       "Error body contains 'invalid token'.");
 
   # Token generated from different issuer/key.
   my $token = Auth::get_auth_token('./src/nginx/t/wrong-client-secret.json');

--- a/src/nginx/t/auth_symmetrickey.t
+++ b/src/nginx/t/auth_symmetrickey.t
@@ -126,7 +126,7 @@ like($response, qr/HTTP\/1\.1 401 Unauthorized/, 'Returned HTTP 401, invalid tok
 like($response, qr/WWW-Authenticate: Bearer, error=\"invalid_token\"/, 'Returned invalid_token challenge.');
 like($response, qr/Content-Type: application\/json/i,
      'Invalid token returned application/json body.');
-like($response, qr/JWT validation failed: BAD_FORMAT/i,
+like($response, qr/JWT validation failed: Bad JWT format: Invalid JSON in header/i,
      "Error body contains 'bad format'.");
 
 # Token generated from different issuer/key.

--- a/src/nginx/t/grpc_auth_pkey.t
+++ b/src/nginx/t/grpc_auth_pkey.t
@@ -151,7 +151,7 @@ results {
 results {
   status {
     code: 16
-    details: "JWT validation failed: BAD_FORMAT"
+    details: "JWT validation failed: Bad JWT format: Invalid JSON in header"
   }
 }
 results {

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -60,6 +60,8 @@ cc_binary(
     ],
 )
 
+# This standalone binary can be used to debug
+# a JWT token with its public key.
 cc_binary(
     name = "verify_token",
     srcs = [

--- a/src/tools/BUILD
+++ b/src/tools/BUILD
@@ -56,7 +56,17 @@ cc_binary(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//external:api_manager_auth_lib",
+        "//src/api_manager/auth/lib",
+    ],
+)
+
+cc_binary(
+    name = "verify_token",
+    srcs = [
+        "verify_token.cc",
+    ],
+    deps = [
+        "//src/api_manager/auth/lib",
     ],
 )
 

--- a/src/tools/verify_token.cc
+++ b/src/tools/verify_token.cc
@@ -1,0 +1,80 @@
+
+// Copyright (C) Extensible Service Proxy Authors
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+// OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+// HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+// LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+// OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+// SUCH DAMAGE.
+//
+////////////////////////////////////////////////////////////////////////////////
+//
+#include <stdio.h>
+#include <string.h>
+#include <memory>
+#include <string>
+#include <iostream>
+
+#include "src/api_manager/auth/lib/auth_token.h"
+#include "src/api_manager/auth/lib/auth_jwt_validator.h"
+
+namespace {
+
+const int MAX_BUF_SIZE = 10240;
+
+}  //  namespace
+
+void print_usage() {
+  std::cerr <<
+      "Invalid argument.\n"
+      "Usage: verify_token token_file public_key_file\n";
+}
+
+std::string read_file(const char* file) {
+  std::cerr << "==Reading file: " << file << std::endl;
+  FILE *fp = fopen(file, "r");
+  char buf[MAX_BUF_SIZE];
+  size_t buf_len = fread(buf, 1, sizeof(buf), fp);
+  fclose(fp);
+  buf[buf_len] = 0;
+  return std::string(buf, buf_len);
+}
+
+int main(int argc, char **argv) {
+  if (argc <= 2) {
+    print_usage();
+    return 1;
+  }
+  //  ::google::api_manager::auth::esp_init_grpc_log();
+
+  std::string token = read_file(argv[1]);
+  std::string jwks = read_file(argv[2]);
+
+  std::cerr << "Token:" << token << std::endl;
+  std::cerr << "Jwks:" << jwks << std::endl;
+
+  auto validator = ::google::api_manager::auth::JwtValidator::Create(token.c_str(), token.size());
+  ::google::api_manager::UserInfo user_info;
+  auto status1 = validator->Parse(&user_info);
+  std::cerr << "Parse result: " << status1.ToString() << std::endl;
+
+  auto status2 = validator->VerifySignature(jwks.c_str(), jwks.size());
+  std::cerr << "Varify result: " << status2.ToString() << std::endl;
+  return 0;
+}

--- a/src/tools/verify_token.cc
+++ b/src/tools/verify_token.cc
@@ -46,7 +46,7 @@ void print_usage() {
 }
 
 std::string read_file(const char *file) {
-  std::cerr << "==Reading file: " << file << std::endl;
+  std::cout << "==Reading file: " << file << std::endl;
   FILE *fp = fopen(file, "r");
   char buf[MAX_BUF_SIZE];
   size_t buf_len = fread(buf, 1, sizeof(buf), fp);
@@ -60,21 +60,20 @@ int main(int argc, char **argv) {
     print_usage();
     return 1;
   }
-  //  ::google::api_manager::auth::esp_init_grpc_log();
 
   std::string token = read_file(argv[1]);
   std::string jwks = read_file(argv[2]);
 
-  std::cerr << "Token:" << token << std::endl;
-  std::cerr << "Jwks:" << jwks << std::endl;
+  std::cout << "Token:" << token << std::endl;
+  std::cout << "Jwks:" << jwks << std::endl;
 
   auto validator = ::google::api_manager::auth::JwtValidator::Create(
       token.c_str(), token.size());
   ::google::api_manager::UserInfo user_info;
   auto status1 = validator->Parse(&user_info);
-  std::cerr << "Parse result: " << status1.ToString() << std::endl;
+  std::cout << "==Parse result: " << status1.ToString() << std::endl;
 
   auto status2 = validator->VerifySignature(jwks.c_str(), jwks.size());
-  std::cerr << "Varify result: " << status2.ToString() << std::endl;
+  std::cout << "==Varify result: " << status2.ToString() << std::endl;
   return 0;
 }

--- a/src/tools/verify_token.cc
+++ b/src/tools/verify_token.cc
@@ -27,12 +27,12 @@
 //
 #include <stdio.h>
 #include <string.h>
+#include <iostream>
 #include <memory>
 #include <string>
-#include <iostream>
 
-#include "src/api_manager/auth/lib/auth_token.h"
 #include "src/api_manager/auth/lib/auth_jwt_validator.h"
+#include "src/api_manager/auth/lib/auth_token.h"
 
 namespace {
 
@@ -41,12 +41,11 @@ const int MAX_BUF_SIZE = 10240;
 }  //  namespace
 
 void print_usage() {
-  std::cerr <<
-      "Invalid argument.\n"
-      "Usage: verify_token token_file public_key_file\n";
+  std::cerr << "Invalid argument.\n"
+               "Usage: verify_token token_file public_key_file\n";
 }
 
-std::string read_file(const char* file) {
+std::string read_file(const char *file) {
   std::cerr << "==Reading file: " << file << std::endl;
   FILE *fp = fopen(file, "r");
   char buf[MAX_BUF_SIZE];
@@ -69,7 +68,8 @@ int main(int argc, char **argv) {
   std::cerr << "Token:" << token << std::endl;
   std::cerr << "Jwks:" << jwks << std::endl;
 
-  auto validator = ::google::api_manager::auth::JwtValidator::Create(token.c_str(), token.size());
+  auto validator = ::google::api_manager::auth::JwtValidator::Create(
+      token.c_str(), token.size());
   ::google::api_manager::UserInfo user_info;
   auto status1 = validator->Parse(&user_info);
   std::cerr << "Parse result: " << status1.ToString() << std::endl;


### PR DESCRIPTION
* Pass the detail error in the response for easy debugging.
* Add a tool verify_token to test token verification in a standalone environment.
