### PR TITLE
Add retry for service control calls

### DIFF
--- a/src/api_manager/proto/server_config.proto
+++ b/src/api_manager/proto/server_config.proto
@@ -85,11 +85,11 @@ message ServiceControlConfig {
   ReportAggregatorConfig report_aggregator_config = 4;
 
   // Timeout in milliseconds on service control check requests.
-  // If the value is <= 0, default timeout is 5000 milliseconds.
+  // If the value is <= 0, default timeout is 1000 milliseconds.
   int32 check_timeout_ms = 5;
 
   // Timeout in milliseconds on service control report requests.
-  // If the value is <= 0, default timeout is 15000 milliseconds.
+  // If the value is <= 0, default timeout is 2000 milliseconds.
   int32 report_timeout_ms = 6;
 
   // The intermediate reports for streaming calls should not be more frequent
@@ -100,7 +100,7 @@ message ServiceControlConfig {
   QuotaAggregatorConfig quota_aggregator_config = 8;
 
   // Timeout in milliseconds on service control allocate quota requests.
-  // If the value is <= 0, default timeout is 5000 milliseconds.
+  // If the value is <= 0, default timeout is 1000 milliseconds.
   int32 quota_timeout_ms = 9;
 
   // Config for log HTTP request headers.
@@ -112,6 +112,18 @@ message ServiceControlConfig {
   // Config for log corresponding fields in jwt payload.
   // The value must be a field in JWT payload.
   repeated string log_jwt_payload = 12;
+
+  // The number of retries on service control check calls.
+  // If the value is <= 0, default is 3.
+  int32 check_retries = 13;
+
+  // The number of retries on service control report calls.
+  // If the value is <= 0, default is 5.
+  int32 report_retries = 14;
+
+  // The number of retries on service control allocate quota calls.
+  // If the value is <= 0, default is 1.
+  int32 quota_retries = 15;
 }
 
 // Check aggregator config

--- a/src/api_manager/service_control/aggregated.cc
+++ b/src/api_manager/service_control/aggregated.cc
@@ -137,6 +137,11 @@ ReportAggregationOptions GetReportAggregationOptions(
                                   kReportAggregationFlushIntervalMs);
 }
 
+const std::string& GetEmptyString() {
+  static const std::string* const kEmptyString = new std::string;
+  return *kEmptyString;
+}
+
 }  // namespace
 
 template <class Type>
@@ -528,8 +533,7 @@ const std::string& Aggregated::GetAuthToken<CheckRequest>() {
     return sa_token_->GetAuthToken(
         auth::ServiceAccountToken::JWT_TOKEN_FOR_SERVICE_CONTROL);
   } else {
-    static std::string empty;
-    return empty;
+    return GetEmptyString();
   }
 }
 template <>
@@ -538,8 +542,7 @@ const std::string& Aggregated::GetAuthToken<ReportRequest>() {
     return sa_token_->GetAuthToken(
         auth::ServiceAccountToken::JWT_TOKEN_FOR_SERVICE_CONTROL);
   } else {
-    static std::string empty;
-    return empty;
+    return GetEmptyString();
   }
 }
 template <>
@@ -548,8 +551,7 @@ const std::string& Aggregated::GetAuthToken<AllocateQuotaRequest>() {
     return sa_token_->GetAuthToken(
         auth::ServiceAccountToken::JWT_TOKEN_FOR_QUOTA_CONTROL);
   } else {
-    static std::string empty;
-    return empty;
+    return GetEmptyString();
   }
 }
 

--- a/src/api_manager/service_control/aggregated.cc
+++ b/src/api_manager/service_control/aggregated.cc
@@ -59,11 +59,19 @@ const int kReportAggregationEntries = 10000;
 const int kReportAggregationFlushIntervalMs = 1000;
 
 // The default connection timeout for check requests.
-const int kCheckDefaultTimeoutInMs = 5000;
+const int kCheckDefaultTimeoutInMs = 1000;
 // The default connection timeout for allocate quota requests.
 const int kAllocateQuotaDefaultTimeoutInMs = 1000;
 // The default connection timeout for report requests.
-const int kReportDefaultTimeoutInMs = 15000;
+const int kReportDefaultTimeoutInMs = 2000;
+
+// The default number of retries for check calls.
+const int kCheckDefaultNumberOfRetries = 3;
+// The default number of retries for report calls.
+const int kReportDefaultNumberOfRetries = 5;
+// The default number of retries for allocate quota calls.
+// Allocate quota has fail_open policy, retry once is enough.
+const int kAllocateQuotaDefaultNumberOfRetries = 1;
 
 // The maximum protobuf pool size. All usages of pool alloc() and free() are
 // within a function frame. If no con-current usage, pool size of 1 is enough.
@@ -193,11 +201,45 @@ Aggregated::Aggregated(const std::set<std::string>& logs,
 
 Aggregated::~Aggregated() {}
 
+void Aggregated::InitHttpRequestTimeoutRetries() {
+  check_timeout_ms_ = kCheckDefaultTimeoutInMs;
+  report_timeout_ms_ = kReportDefaultTimeoutInMs;
+  quota_timeout_ms_ = kAllocateQuotaDefaultTimeoutInMs;
+  check_retries_ = kCheckDefaultNumberOfRetries;
+  report_retries_ = kReportDefaultNumberOfRetries;
+  quota_retries_ = kAllocateQuotaDefaultNumberOfRetries;
+
+  if (server_config_ != nullptr &&
+      server_config_->has_service_control_config()) {
+    const auto& config = server_config_->service_control_config();
+    if (config.check_timeout_ms() > 0) {
+      check_timeout_ms_ = config.check_timeout_ms();
+    }
+    if (config.report_timeout_ms() > 0) {
+      report_timeout_ms_ = config.report_timeout_ms();
+    }
+    if (config.quota_timeout_ms() > 0) {
+      quota_timeout_ms_ = config.quota_timeout_ms();
+    }
+    if (config.check_retries() > 0) {
+      check_retries_ = config.check_retries();
+    }
+    if (config.report_retries() > 0) {
+      report_retries_ = config.report_retries();
+    }
+    if (config.quota_retries() > 0) {
+      quota_retries_ = config.quota_retries();
+    }
+  }
+}
+
 Status Aggregated::Init() {
   // Init() can be called repeatedly.
   if (client_) {
     return Status::OK;
   }
+
+  InitHttpRequestTimeoutRetries();
 
   // It is too early to create client_ at constructor.
   // Client creation is calling env->StartPeriodicTimer.
@@ -441,61 +483,70 @@ Status Aggregated::GetStatistics(Statistics* esp_stat) const {
   return Status::OK;
 }
 
-template <class RequestType>
-const std::string& Aggregated::GetApiRequestUrl() {
-  if (typeid(RequestType) == typeid(CheckRequest)) {
-    return url_.check_url();
-  } else if (typeid(RequestType) == typeid(AllocateQuotaRequest)) {
-    return url_.quota_url();
-  } else {
-    return url_.report_url();
-  }
+template <>
+const std::string& Aggregated::GetApiRequestUrl<CheckRequest>() {
+  return url_.check_url();
+}
+template <>
+const std::string& Aggregated::GetApiRequestUrl<ReportRequest>() {
+  return url_.report_url();
+}
+template <>
+const std::string& Aggregated::GetApiRequestUrl<AllocateQuotaRequest>() {
+  return url_.quota_url();
 }
 
-template <class RequestType>
-int Aggregated::GetHttpRequestTimeout() {
-  int timeout_ms = 0;
-
-  // Set timeout on the request if it was so configured.
-  if (typeid(RequestType) == typeid(CheckRequest)) {
-    timeout_ms = kCheckDefaultTimeoutInMs;
-  } else if (typeid(RequestType) == typeid(AllocateQuotaRequest)) {
-    timeout_ms = kAllocateQuotaDefaultTimeoutInMs;
-  } else {
-    timeout_ms = kReportDefaultTimeoutInMs;
-  }
-
-  if (server_config_ != nullptr &&
-      server_config_->has_service_control_config()) {
-    const auto& config = server_config_->service_control_config();
-    if (typeid(RequestType) == typeid(CheckRequest)) {
-      if (config.check_timeout_ms() > 0) {
-        timeout_ms = config.check_timeout_ms();
-      }
-    } else if (typeid(RequestType) == typeid(AllocateQuotaRequest)) {
-      if (config.quota_timeout_ms() > 0) {
-        timeout_ms = config.quota_timeout_ms();
-      }
-    } else {
-      if (config.report_timeout_ms() > 0) {
-        timeout_ms = config.report_timeout_ms();
-      }
-    }
-  }
-
-  return timeout_ms;
+template <>
+int Aggregated::GetHttpRequestTimeout<CheckRequest>() {
+  return check_timeout_ms_;
+}
+template <>
+int Aggregated::GetHttpRequestTimeout<ReportRequest>() {
+  return report_timeout_ms_;
+}
+template <>
+int Aggregated::GetHttpRequestTimeout<AllocateQuotaRequest>() {
+  return quota_timeout_ms_;
 }
 
-template <class RequestType>
-const std::string& Aggregated::GetAuthToken() {
+template <>
+int Aggregated::GetHttpRequestRetries<CheckRequest>() {
+  return check_retries_;
+}
+template <>
+int Aggregated::GetHttpRequestRetries<ReportRequest>() {
+  return report_retries_;
+}
+template <>
+int Aggregated::GetHttpRequestRetries<AllocateQuotaRequest>() {
+  return quota_retries_;
+}
+
+template <>
+const std::string& Aggregated::GetAuthToken<CheckRequest>() {
   if (sa_token_) {
-    if (typeid(RequestType) == typeid(AllocateQuotaRequest)) {
-      return sa_token_->GetAuthToken(
-          auth::ServiceAccountToken::JWT_TOKEN_FOR_QUOTA_CONTROL);
-    } else {
-      return sa_token_->GetAuthToken(
-          auth::ServiceAccountToken::JWT_TOKEN_FOR_SERVICE_CONTROL);
-    }
+    return sa_token_->GetAuthToken(
+        auth::ServiceAccountToken::JWT_TOKEN_FOR_SERVICE_CONTROL);
+  } else {
+    static std::string empty;
+    return empty;
+  }
+}
+template <>
+const std::string& Aggregated::GetAuthToken<ReportRequest>() {
+  if (sa_token_) {
+    return sa_token_->GetAuthToken(
+        auth::ServiceAccountToken::JWT_TOKEN_FOR_SERVICE_CONTROL);
+  } else {
+    static std::string empty;
+    return empty;
+  }
+}
+template <>
+const std::string& Aggregated::GetAuthToken<AllocateQuotaRequest>() {
+  if (sa_token_) {
+    return sa_token_->GetAuthToken(
+        auth::ServiceAccountToken::JWT_TOKEN_FOR_QUOTA_CONTROL);
   } else {
     static std::string empty;
     return empty;
@@ -544,6 +595,7 @@ void Aggregated::Call(const RequestType& request, ResponseType* response,
   std::string request_body;
   request.SerializeToString(&request_body);
 
+  // Collect statistics on the maximum report body size.
   if ((typeid(RequestType) == typeid(ReportRequest)) &&
       (request_body.size() > max_report_size_)) {
     max_report_size_ = request_body.size();
@@ -556,6 +608,7 @@ void Aggregated::Call(const RequestType& request, ResponseType* response,
       .set_body(request_body);
 
   http_request->set_timeout_ms(GetHttpRequestTimeout<RequestType>());
+  http_request->set_max_retries(GetHttpRequestRetries<RequestType>());
 
   env_->RunHTTPRequest(std::move(http_request));
 }

--- a/src/api_manager/service_control/aggregated.h
+++ b/src/api_manager/service_control/aggregated.h
@@ -110,6 +110,9 @@ class Aggregated : public Interface {
              const std::set<std::string>& metrics,
              const std::set<std::string>& labels);
 
+  // Initialize HttpRequest used timeout and retry values.
+  void InitHttpRequestTimeoutRetries();
+
   // Calls to service control server.
   template <class RequestType, class ResponseType>
   void Call(const RequestType& request, ResponseType* response,
@@ -123,6 +126,10 @@ class Aggregated : public Interface {
   // Returns API request timeout in ms based on RequestType
   template <class RequestType>
   int GetHttpRequestTimeout();
+
+  // Returns API request number of retries based on RequestType
+  template <class RequestType>
+  int GetHttpRequestRetries();
 
   // Returns API request auth token based on RequestType
   template <class RequestType>
@@ -166,6 +173,16 @@ class Aggregated : public Interface {
 
   // Maximum report size send to server.
   uint64_t max_report_size_;
+
+  // the configurable timeouts
+  int check_timeout_ms_;
+  int report_timeout_ms_;
+  int quota_timeout_ms_;
+
+  // the configurable retries
+  int check_retries_;
+  int report_retries_;
+  int quota_retries_;
 };
 
 }  // namespace service_control

--- a/src/nginx/t/BUILD
+++ b/src/nginx/t/BUILD
@@ -255,6 +255,7 @@ nginx_suite(
     nginx = "//src/nginx/main:nginx-esp",
     tests = [
         "check_network_failures.t",
+        "test_timeout_retry.t",
     ],
     deps = [
         ":perl_library",

--- a/src/nginx/t/check_network_failures.t
+++ b/src/nginx/t/check_network_failures.t
@@ -46,6 +46,7 @@ my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(13);
 ApiManager::write_file_expand($t, 'sc_timeout.pb.txt', <<"EOF");
 service_control_config {
   check_timeout_ms: 1000
+  check_retries: 1
 }
 EOF
 

--- a/src/nginx/t/test_timeout_retry.t
+++ b/src/nginx/t/test_timeout_retry.t
@@ -1,0 +1,198 @@
+# Copyright (C) Extensible Service Proxy Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+################################################################################
+#
+use strict;
+use warnings;
+
+################################################################################
+
+use src::nginx::t::ApiManager;   # Must be first (sets up import path to the Nginx test module)
+use src::nginx::t::HttpServer;
+use Test::Nginx;  # Imports Nginx's test module
+use Test::More;   # And the test framework
+
+################################################################################
+
+# Port assignments
+my $NginxPort = ApiManager::pick_port();
+my $BackendPort = ApiManager::pick_port();
+my $ServiceControlPort = ApiManager::pick_port();
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(10);
+
+ApiManager::write_file_expand($t, 'sc_timeout.pb.txt', <<"EOF");
+service_control_config {
+  check_aggregator_config {
+    cache_entries: 0
+  }
+  report_aggregator_config {
+    cache_entries: 0
+  }
+  check_timeout_ms: 500
+  check_retries: 2
+  report_timeout_ms: 500
+  report_retries: 2
+}
+EOF
+
+$t->write_file('service.pb.txt', ApiManager::get_bookstore_service_config . <<"EOF");
+control {
+  environment: "http://127.0.0.1:${ServiceControlPort}"
+}
+EOF
+
+ApiManager::write_file_expand($t, 'nginx.conf', <<"EOF");
+%%TEST_GLOBALS%%
+daemon off;
+events {
+  worker_connections 32;
+}
+http {
+  %%TEST_GLOBALS_HTTP%%
+  server_tokens off;
+  server {
+    listen 127.0.0.1:${NginxPort};
+    server_name localhost;
+    location / {
+      endpoints {
+        api service.pb.txt;
+        server_config sc_timeout.pb.txt;
+        on;
+      }
+      proxy_pass http://127.0.0.1:${BackendPort};
+    }
+  }
+}
+EOF
+
+my $report_done = $t->{_testdir} . '/report_done.log';
+
+$t->run_daemon(\&bookstore, $t, $BackendPort, 'bookstore.log');
+$t->run_daemon(\&servicecontrol, $t, $ServiceControlPort, $report_done, 'servicecontrol.log');
+is($t->waitforsocket("127.0.0.1:${BackendPort}"), 1, 'Bookstore socket ready.');
+is($t->waitforsocket("127.0.0.1:${ServiceControlPort}"), 1, 'Service control socket ready.');
+$t->run();
+
+my $response = ApiManager::http_get($NginxPort,'/shelves?key=this-is-an-api-key');
+
+is($t->waitforfile($report_done), 1, 'Report body file ready.');
+
+$t->stop();
+$t->stop_daemons();
+
+my ($response_headers, $response_body) = split /\r\n\r\n/, $response, 2;
+
+like($response_headers, qr/HTTP\/1\.1 200 OK/, 'Returned HTTP 200.');
+is($response_body, <<'EOF', 'Shelves returned in the response body.');
+{ "shelves": [
+    { "name": "shelves/1", "theme": "Fiction" },
+    { "name": "shelves/2", "theme": "Fantasy" }
+  ]
+}
+EOF
+
+# Verify ServiceControl was called.
+my @servicecontrol_requests = ApiManager::read_http_stream($t, 'servicecontrol.log');
+is(scalar @servicecontrol_requests, 4, 'Service control was called 4 times.');
+
+my ($check1, $check2, $report1, $report2) = @servicecontrol_requests;
+like($check1->{uri}, qr/:check$/, 'First call is Check');
+like($check2->{uri}, qr/:check$/, 'Second call is Check');
+like($report1->{uri}, qr/:report$/, 'Third call is Report');
+like($report2->{uri}, qr/:report$/, 'Fourth call is Report');
+
+################################################################################
+
+sub servicecontrol {
+  my ($t, $port, $done, $file) = @_;
+  my $server = HttpServer->new($port, $t->testdir() . '/' . $file)
+    or die "Can't create test server socket: $!\n";
+  local $SIG{PIPE} = 'IGNORE';
+  my $check_request_count = 0;
+  my $report_request_count = 0;
+
+  $server->on_sub('POST', '/v1/services/endpoints-test.cloudendpointsapis.com:check', sub {
+    my ($headers, $body, $client) = @_;
+
+    $check_request_count++;
+    if ($check_request_count != 2) {
+        # sleep 1 second to cause timeout
+        sleep 1;
+    }
+
+    print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+EOF
+  });
+
+  $server->on_sub('POST', '/v1/services/endpoints-test.cloudendpointsapis.com:report', sub {
+    my ($headers, $body, $client) = @_;
+
+    $report_request_count++;
+    if ($report_request_count != 2) {
+        # sleep 1 second to cause timeout
+        sleep 1;
+    }
+
+    print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+EOF
+
+    ApiManager::write_binary_file($done, ':report done');
+  });
+
+  $server->run();
+}
+
+################################################################################
+
+sub bookstore {
+  my ($t, $port, $file) = @_;
+  my $server = HttpServer->new($port, $t->testdir() . '/' . $file)
+    or die "Can't create test server socket: $!\n";
+  local $SIG{PIPE} = 'IGNORE';
+
+  $server->on_sub('GET', '/shelves', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+{ "shelves": [
+    { "name": "shelves/1", "theme": "Fiction" },
+    { "name": "shelves/2", "theme": "Fantasy" }
+  ]
+}
+EOF
+  });
+  $server->run();
+}
+
+################################################################################


### PR DESCRIPTION
Service Control calls sometime may encounter long latency. It can be worked around by reducing timeout  with retries.

With this changes:  Here are the default timeout and retries

Check: timeout 1s and retries: 3 
Report:  timeout 2s and retries: 5
Quota: timeout 1s, and retries: 1