### PR TITLE
Change default timeout

### DIFF
--- a/src/api_manager/proto/server_config.proto
+++ b/src/api_manager/proto/server_config.proto
@@ -85,11 +85,11 @@ message ServiceControlConfig {
   ReportAggregatorConfig report_aggregator_config = 4;
 
   // Timeout in milliseconds on service control check requests.
-  // If the value is <= 0, default timeout is 1000 milliseconds.
+  // If the value is <= 0, default timeout is 1500 milliseconds.
   int32 check_timeout_ms = 5;
 
   // Timeout in milliseconds on service control report requests.
-  // If the value is <= 0, default timeout is 2000 milliseconds.
+  // If the value is <= 0, default timeout is 3500 milliseconds.
   int32 report_timeout_ms = 6;
 
   // The intermediate reports for streaming calls should not be more frequent
@@ -100,7 +100,7 @@ message ServiceControlConfig {
   QuotaAggregatorConfig quota_aggregator_config = 8;
 
   // Timeout in milliseconds on service control allocate quota requests.
-  // If the value is <= 0, default timeout is 1000 milliseconds.
+  // If the value is <= 0, default timeout is 1500 milliseconds.
   int32 quota_timeout_ms = 9;
 
   // Config for log HTTP request headers.

--- a/src/api_manager/service_control/aggregated.cc
+++ b/src/api_manager/service_control/aggregated.cc
@@ -59,11 +59,15 @@ const int kReportAggregationEntries = 10000;
 const int kReportAggregationFlushIntervalMs = 1000;
 
 // The default connection timeout for check requests.
-const int kCheckDefaultTimeoutInMs = 1000;
+// 1.5s Check timeout is based on SYN resend timeout is 1s.
+const int kCheckDefaultTimeoutInMs = 1500;
 // The default connection timeout for allocate quota requests.
-const int kAllocateQuotaDefaultTimeoutInMs = 1000;
+// 1.5s Quota timeout is based on SYN resend timeout is 1s.
+const int kAllocateQuotaDefaultTimeoutInMs = 1500;
 // The default connection timeout for report requests.
-const int kReportDefaultTimeoutInMs = 2000;
+// 3.5s Report timeout is based on SYN resend timeout is 1s.
+// and Server processing Report is much slower.
+const int kReportDefaultTimeoutInMs = 3500;
 
 // The default number of retries for check calls.
 const int kCheckDefaultNumberOfRetries = 3;


### PR DESCRIPTION
Since SYN resend timeout is 1s.  Change the default time to allow at least one SYN resend