### PR TITLE
Use the service_rollout_id from Check/Report response

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -588,9 +588,9 @@ cc_proto_library(
         name = "googleapis_git",
         build_file_content = BUILD,
         patch_cmds = ["find . -type f -name '*BUILD*' | xargs rm"],
-        strip_prefix = "googleapis-275cdfcdc3188a60456f43acd139b8cc037379f4",  # May 14, 2019
-        url = "https://github.com/googleapis/googleapis/archive/275cdfcdc3188a60456f43acd139b8cc037379f4.tar.gz",
-        sha256 = "d07a9bf06bb02b51ff6e913211cedc7511430af550b6a775908c33c8ee218985",
+        strip_prefix = "googleapis-33602a3174cc7b5d1726aebed4836c3bd7725469",  # forked with rollout_id
+        url = "https://github.com/qiwzhang/googleapis/archive/33602a3174cc7b5d1726aebed4836c3bd7725469.tar.gz",
+        sha256 = "fa1274fe2d5b59e957be2a63edf2b4c058b1c3e228857e9724cd51c8f374873c",
     )
 
     if bind:

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -589,6 +589,8 @@ cc_proto_library(
         build_file_content = BUILD,
         patch_cmds = ["find . -type f -name '*BUILD*' | xargs rm"],
         strip_prefix = "googleapis-33602a3174cc7b5d1726aebed4836c3bd7725469",  # forked with rollout_id
+        # TODO(qiwzhang): use forked repo with manually added service_rollout_id field
+        # Switch over once googleapis repo has the latest proto files.
         url = "https://github.com/qiwzhang/googleapis/archive/33602a3174cc7b5d1726aebed4836c3bd7725469.tar.gz",
         sha256 = "fa1274fe2d5b59e957be2a63edf2b4c058b1c3e228857e9724cd51c8f374873c",
     )

--- a/src/api_manager/config_manager.cc
+++ b/src/api_manager/config_manager.cc
@@ -82,13 +82,11 @@ void ConfigManager::OnRolloutsRefreshTimer() {
     return;
   }
 
-  // Check the rollout id from Check/Report response and stored in
-  // global_context
-  // This rollout id is fresh and it is fetched since previous timeout.
+  // The rollout id in global_context is from Check/Report response.
+  // It is fresh and should have been fetched since last timeout.
   if (!global_context_->rollout_id().empty()) {
-    // If the fresh rollout id is the same as the current one, bailout
     bool bail_out = (global_context_->rollout_id() == current_rollout_id_);
-    // Clear the rollout_id to make sure it is fresh at next timeout.
+    // Clear it to make sure it is fresh for the next timeout
     global_context_->set_rollout_id("");
     if (bail_out) {
       return;

--- a/src/api_manager/config_manager.cc
+++ b/src/api_manager/config_manager.cc
@@ -81,6 +81,20 @@ void ConfigManager::OnRolloutsRefreshTimer() {
       window_request_counter_->Count(std::chrono::system_clock::now()) == 0) {
     return;
   }
+
+  // Check the rollout id from Check/Report response and stored in
+  // global_context
+  // This rollout id is fresh and it is fetched since previous timeout.
+  if (!global_context_->rollout_id().empty()) {
+    // If the fresh rollout id is the same as the current one, bailout
+    bool bail_out = (global_context_->rollout_id() == current_rollout_id_);
+    // Clear the rollout_id to make sure it is fresh at next timeout.
+    global_context_->set_rollout_id("");
+    if (bail_out) {
+      return;
+    }
+  }
+
   std::string audience;
   GlobalFetchServiceAccountToken(
       global_context_, audience, [this](utils::Status status) {

--- a/src/api_manager/config_manager_test.cc
+++ b/src/api_manager/config_manager_test.cc
@@ -299,21 +299,21 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
   config_manager->Init();
   ASSERT_EQ(0, sequence);
 
-  // set rollout_id to 2017-05-01r0 which is same as one from from
-  // global_context
+  // Set the same rollout_id to config_manager and global_context
   config_manager->set_current_rollout_id("2017-05-01r0");
   global_context_->set_rollout_id("2017-05-01r0");
   config_manager->CountRequests(1);
 
-  // This is not called at first timeer
+  // So no need to make rollout HTTP call.
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_)).Times(0);
 
   raw_env_->RunTimer();
   // callback should not be called
   ASSERT_EQ(0, sequence);
 
-  // global_context_->set_rollout_id() is not called
-  // So Http request to inception rollout is called, but ID did not changed
+  // Not calling global_context_->set_rollout_id() means there
+  // is not Check or Report called since last timeout.
+  // So Http request to get rollout is called, but ID did not changed
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
         ASSERT_EQ(
@@ -327,7 +327,8 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
   // callback should not be called
   ASSERT_EQ(0, sequence);
 
-  // global_context_->set_rollout_id() is called with different id
+  // Call global_context_->set_rollout_id() with different id
+  // to simulate Report/Check response get a new rollout id,
   global_context_->set_rollout_id("2017-05-01r111");
   // So Http request to inception rollout is called, but ID did not changed
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))

--- a/src/api_manager/config_manager_test.cc
+++ b/src/api_manager/config_manager_test.cc
@@ -283,6 +283,67 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
   ASSERT_EQ(0, sequence);
 }
 
+TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
+  int sequence = 0;
+  std::shared_ptr<ConfigManager> config_manager(new ConfigManager(
+      global_context_,
+      [this, &sequence](const utils::Status& status,
+                        const std::vector<std::pair<std::string, int>>& list) {
+
+        ASSERT_EQ(1, list.size());
+        ASSERT_EQ(kServiceConfig1, list[0].first);
+        ASSERT_EQ(100, list[0].second);
+        sequence++;
+      }));
+
+  config_manager->Init();
+  ASSERT_EQ(0, sequence);
+
+  // set rollout_id to 2017-05-01r0 which is same as one from from
+  // global_context
+  config_manager->set_current_rollout_id("2017-05-01r0");
+  global_context_->set_rollout_id("2017-05-01r0");
+  config_manager->CountRequests(1);
+
+  // This is not called at first timeer
+  EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_)).Times(0);
+
+  raw_env_->RunTimer();
+  // callback should not be called
+  ASSERT_EQ(0, sequence);
+
+  // global_context_->set_rollout_id() is not called
+  // So Http request to inception rollout is called, but ID did not changed
+  EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
+      .WillOnce(Invoke([this](HTTPRequest* req) {
+        ASSERT_EQ(
+            "https://servicemanagement.googleapis.com/v1/services/"
+            "service_name_from_metadata/rollouts?filter=status=SUCCESS",
+            req->url());
+        req->OnComplete(Status::OK, {}, kRolloutsResponse1);
+      }));
+
+  raw_env_->RunTimer();
+  // callback should not be called
+  ASSERT_EQ(0, sequence);
+
+  // global_context_->set_rollout_id() is called with different id
+  global_context_->set_rollout_id("2017-05-01r111");
+  // So Http request to inception rollout is called, but ID did not changed
+  EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
+      .WillOnce(Invoke([this](HTTPRequest* req) {
+        ASSERT_EQ(
+            "https://servicemanagement.googleapis.com/v1/services/"
+            "service_name_from_metadata/rollouts?filter=status=SUCCESS",
+            req->url());
+        req->OnComplete(Status::OK, {}, kRolloutsResponse1);
+      }));
+
+  raw_env_->RunTimer();
+  // callback should not be called
+  ASSERT_EQ(0, sequence);
+}
+
 TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutMultipleServiceConfig) {
   std::function<void(HTTPRequest * req)> hanlder = [this](HTTPRequest* req) {
     std::map<std::string, std::string> data = {

--- a/src/api_manager/config_manager_test.cc
+++ b/src/api_manager/config_manager_test.cc
@@ -216,14 +216,14 @@ class ConfigManagerServiceNameConfigIdTest : public ::testing::Test {
 TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutSingleServiceConfig) {
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
         req->OnComplete(Status::OK, {}, kRolloutsResponse1);
       }))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/configs/2017-05-01r0",
             req->url());
@@ -236,24 +236,24 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutSingleServiceConfig) {
       [this, &sequence](const utils::Status& status,
                         const std::vector<std::pair<std::string, int>>& list) {
 
-        ASSERT_EQ(1, list.size());
-        ASSERT_EQ(kServiceConfig1, list[0].first);
-        ASSERT_EQ(100, list[0].second);
+        EXPECT_EQ(1, list.size());
+        EXPECT_EQ(kServiceConfig1, list[0].first);
+        EXPECT_EQ(100, list[0].second);
         sequence++;
       }));
 
   config_manager->Init();
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   config_manager->CountRequests(1);
   raw_env_->RunTimer();
-  ASSERT_EQ(1, sequence);
+  EXPECT_EQ(1, sequence);
 }
 
 TEST_F(ConfigManagerServiceNameConfigIdTest,
        RemoteRolloutIDIsSameAsRolloutIDInServerConfig) {
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -266,9 +266,9 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
       [this, &sequence](const utils::Status& status,
                         const std::vector<std::pair<std::string, int>>& list) {
 
-        ASSERT_EQ(1, list.size());
-        ASSERT_EQ(kServiceConfig1, list[0].first);
-        ASSERT_EQ(100, list[0].second);
+        EXPECT_EQ(1, list.size());
+        EXPECT_EQ(kServiceConfig1, list[0].first);
+        EXPECT_EQ(100, list[0].second);
         sequence++;
       }));
 
@@ -276,11 +276,11 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
   config_manager->set_current_rollout_id("2017-05-01r0");
 
   config_manager->Init();
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // callback should not be called
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
 }
 
 TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
@@ -290,14 +290,14 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
       [this, &sequence](const utils::Status& status,
                         const std::vector<std::pair<std::string, int>>& list) {
 
-        ASSERT_EQ(1, list.size());
-        ASSERT_EQ(kServiceConfig1, list[0].first);
-        ASSERT_EQ(100, list[0].second);
+        EXPECT_EQ(1, list.size());
+        EXPECT_EQ(kServiceConfig1, list[0].first);
+        EXPECT_EQ(100, list[0].second);
         sequence++;
       }));
 
   config_manager->Init();
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
 
   // Set the same rollout_id to config_manager and global_context
   config_manager->set_current_rollout_id("2017-05-01r0");
@@ -309,14 +309,14 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
 
   raw_env_->RunTimer();
   // callback should not be called
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
 
   // Not calling global_context_->set_rollout_id() means there
   // is not Check or Report called since last timeout.
   // So Http request to get rollout is called, but ID did not changed
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -325,7 +325,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
 
   raw_env_->RunTimer();
   // callback should not be called
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
 
   // Call global_context_->set_rollout_id() with different id
   // to simulate Report/Check response get a new rollout id,
@@ -333,7 +333,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
   // So Http request to inception rollout is called, but ID did not changed
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -342,7 +342,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, ResponseRolloutID) {
 
   raw_env_->RunTimer();
   // callback should not be called
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
 }
 
 TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutMultipleServiceConfig) {
@@ -364,7 +364,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutMultipleServiceConfig) {
 
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -381,19 +381,19 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutMultipleServiceConfig) {
                         std::vector<std::pair<std::string, int>> list) {
         std::sort(list.begin(), list.end());
 
-        ASSERT_EQ(2, list.size());
-        ASSERT_EQ(kServiceConfig1, list[0].first);
-        ASSERT_EQ(80, list[0].second);
-        ASSERT_EQ(kServiceConfig2, list[1].first);
-        ASSERT_EQ(20, list[1].second);
+        EXPECT_EQ(2, list.size());
+        EXPECT_EQ(kServiceConfig1, list[0].first);
+        EXPECT_EQ(80, list[0].second);
+        EXPECT_EQ(kServiceConfig2, list[1].first);
+        EXPECT_EQ(20, list[1].second);
         sequence++;
       }));
 
   config_manager->Init();
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   config_manager->CountRequests(1);
   raw_env_->RunTimer();
-  ASSERT_EQ(1, sequence);
+  EXPECT_EQ(1, sequence);
 }
 
 TEST_F(ConfigManagerServiceNameConfigIdTest,
@@ -431,7 +431,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
 
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -440,7 +440,7 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
       .WillOnce(Invoke(first_hanlder))
       .WillOnce(Invoke(first_hanlder))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -459,42 +459,42 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
       }));
 
   config_manager->Init();
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // One of ServiceConfig download was failed. The callback should not be
   // invoked
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   // Succeeded on the next timer event. Invoke the callback function
   raw_env_->RunTimer();
-  ASSERT_EQ(1, sequence);
+  EXPECT_EQ(1, sequence);
 }
 
 TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutSingleServiceConfigUpdate) {
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
         req->OnComplete(Status::OK, {}, kRolloutsResponse1);
       }))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/configs/2017-05-01r0",
             req->url());
         req->OnComplete(Status::OK, {}, kServiceConfig1);
       }))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
         req->OnComplete(Status::OK, {}, kRolloutsResponse2);
       }))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/configs/2017-05-01r1",
             req->url());
@@ -508,47 +508,47 @@ TEST_F(ConfigManagerServiceNameConfigIdTest, RolloutSingleServiceConfigUpdate) {
       [this, &sequence](const utils::Status& status,
                         const std::vector<std::pair<std::string, int>>& list) {
 
-        ASSERT_EQ(1, list.size());
+        EXPECT_EQ(1, list.size());
 
         // depends on sequence, different service_config will downloaded
-        ASSERT_EQ(sequence == 0 ? kServiceConfig1 : kServiceConfig2,
+        EXPECT_EQ(sequence == 0 ? kServiceConfig1 : kServiceConfig2,
                   list[0].first);
 
-        ASSERT_EQ(100, list[0].second);
+        EXPECT_EQ(100, list[0].second);
 
         sequence++;
       }));
 
   config_manager->Init();
   // run first periodic timer
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // run second periodic timer
-  ASSERT_EQ(1, sequence);
+  EXPECT_EQ(1, sequence);
   raw_env_->RunTimer();
-  ASSERT_EQ(2, sequence);
+  EXPECT_EQ(2, sequence);
 }
 
 TEST_F(ConfigManagerServiceNameConfigIdTest,
        RolloutSingleServiceConfigNoupdate) {
   EXPECT_CALL(*raw_env_, DoRunHTTPRequest(_))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
         req->OnComplete(Status::OK, {}, kRolloutsResponse1);
       }))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/configs/2017-05-01r0",
             req->url());
         req->OnComplete(Status::OK, {}, kServiceConfig1);
       }))
       .WillOnce(Invoke([this](HTTPRequest* req) {
-        ASSERT_EQ(
+        EXPECT_EQ(
             "https://servicemanagement.googleapis.com/v1/services/"
             "service_name_from_metadata/rollouts?filter=status=SUCCESS",
             req->url());
@@ -561,23 +561,23 @@ TEST_F(ConfigManagerServiceNameConfigIdTest,
       [this, &sequence](const utils::Status& status,
                         const std::vector<std::pair<std::string, int>>& list) {
 
-        ASSERT_EQ(1, list.size());
-        ASSERT_EQ(kServiceConfig1, list[0].first);
-        ASSERT_EQ(100, list[0].second);
+        EXPECT_EQ(1, list.size());
+        EXPECT_EQ(kServiceConfig1, list[0].first);
+        EXPECT_EQ(100, list[0].second);
 
         sequence++;
       }));
 
   config_manager->Init();
   // run first periodic timer
-  ASSERT_EQ(0, sequence);
+  EXPECT_EQ(0, sequence);
   config_manager->CountRequests(1);
   raw_env_->RunTimer();
   // run second periodic timer
-  ASSERT_EQ(1, sequence);
+  EXPECT_EQ(1, sequence);
   raw_env_->RunTimer();
   // Same rollout_id, no update
-  ASSERT_EQ(1, sequence);
+  EXPECT_EQ(1, sequence);
 }
 
 }  // namespace

--- a/src/api_manager/context/global_context.h
+++ b/src/api_manager/context/global_context.h
@@ -95,7 +95,7 @@ class GlobalContext {
   void set_rollout_id(const std::string &rollout_id) {
     rollout_id_ = rollout_id;
   }
-  const std::string& rollout_id() const { return rollout_id_; }
+  const std::string &rollout_id() const { return rollout_id_; }
 
  private:
   // create cloud trace.

--- a/src/api_manager/context/global_context.h
+++ b/src/api_manager/context/global_context.h
@@ -15,6 +15,8 @@
 #ifndef API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_
 #define API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_
 
+#include <chrono>
+
 #include "src/api_manager/auth/authz_cache.h"
 #include "src/api_manager/auth/certs.h"
 #include "src/api_manager/auth/jwt_cache.h"
@@ -92,6 +94,11 @@ class GlobalContext {
 
   int jwks_cache_duration_in_s() const { return jwks_cache_duration_in_s_; }
 
+  void set_rollout_id(const std::string &rollout_id) {
+    rollout_id_from_response_ = rollout_id;
+    rollout_id_response_time_ = std::chrono::system_clock::now();
+  }
+
  private:
   // create cloud trace.
   std::unique_ptr<cloud_trace::Aggregator> CreateCloudTraceAggregator();
@@ -138,6 +145,11 @@ class GlobalContext {
 
   // The jwks public key cache duration.
   int jwks_cache_duration_in_s_;
+
+  // The rollout id fetched from Check and Report response.
+  std::string rollout_id_from_response_;
+  // The time response is received.
+  std::chrono::system_clock::time_point rollout_id_response_time_;
 };
 
 }  // namespace context

--- a/src/api_manager/context/global_context.h
+++ b/src/api_manager/context/global_context.h
@@ -15,8 +15,6 @@
 #ifndef API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_
 #define API_MANAGER_CONTEXT_GLOBAL_CONTEXT_H_
 
-#include <chrono>
-
 #include "src/api_manager/auth/authz_cache.h"
 #include "src/api_manager/auth/certs.h"
 #include "src/api_manager/auth/jwt_cache.h"
@@ -95,9 +93,9 @@ class GlobalContext {
   int jwks_cache_duration_in_s() const { return jwks_cache_duration_in_s_; }
 
   void set_rollout_id(const std::string &rollout_id) {
-    rollout_id_from_response_ = rollout_id;
-    rollout_id_response_time_ = std::chrono::system_clock::now();
+    rollout_id_ = rollout_id;
   }
+  const std::string& rollout_id() const { return rollout_id_; }
 
  private:
   // create cloud trace.
@@ -147,9 +145,7 @@ class GlobalContext {
   int jwks_cache_duration_in_s_;
 
   // The rollout id fetched from Check and Report response.
-  std::string rollout_id_from_response_;
-  // The time response is received.
-  std::chrono::system_clock::time_point rollout_id_response_time_;
+  std::string rollout_id_;
 };
 
 }  // namespace context

--- a/src/api_manager/context/service_context.cc
+++ b/src/api_manager/context/service_context.cc
@@ -71,7 +71,10 @@ std::unique_ptr<service_control::Interface> ServiceContext::CreateInterface() {
   return std::unique_ptr<service_control::Interface>(
       service_control::Aggregated::Create(
           config_->service(), global_context_->server_config().get(), env(),
-          global_context_->service_account_token()));
+          global_context_->service_account_token(),
+          [this](const std::string& rollout_id) {
+            global_context_->set_rollout_id(rollout_id);
+          }));
 }
 
 }  // namespace context

--- a/src/api_manager/service_control/aggregated.h
+++ b/src/api_manager/service_control/aggregated.h
@@ -34,13 +34,18 @@ namespace google {
 namespace api_manager {
 namespace service_control {
 
+// The function prototype to set the latest rollout id
+// from Check and Report response.
+typedef std::function<void(const std::string& rollout_id)> SetRolloutIdFunc;
+
 // This implementation uses service-control-client-cxx module.
 class Aggregated : public Interface {
  public:
   static Interface* Create(const ::google::api::Service& service,
                            const proto::ServerConfig* server_config,
                            ApiManagerEnvInterface* env,
-                           auth::ServiceAccountToken* sa_token);
+                           auth::ServiceAccountToken* sa_token,
+                           SetRolloutIdFunc set_rollout_id_func);
 
   virtual ~Aggregated();
 
@@ -108,7 +113,8 @@ class Aggregated : public Interface {
              ApiManagerEnvInterface* env, auth::ServiceAccountToken* sa_token,
              const std::set<std::string>& logs,
              const std::set<std::string>& metrics,
-             const std::set<std::string>& labels);
+             const std::set<std::string>& labels,
+             SetRolloutIdFunc set_rollout_id_func);
 
   // Initialize HttpRequest used timeout and retry values.
   void InitHttpRequestTimeoutRetries();
@@ -134,6 +140,9 @@ class Aggregated : public Interface {
   // Returns API request auth token based on RequestType
   template <class RequestType>
   const std::string& GetAuthToken();
+
+  template <class ResponseType>
+  void HandleResponse(const ResponseType& response);
 
   // the sevice config.
   const ::google::api::Service* service_;
@@ -186,6 +195,10 @@ class Aggregated : public Interface {
 
   // network fail policy, default to false
   bool network_fail_open_{};
+
+  // The callback function to set the latest rollout id
+  // from Check and Report response
+  SetRolloutIdFunc set_rollout_id_func_;
 };
 
 }  // namespace service_control

--- a/src/nginx/t/BUILD
+++ b/src/nginx/t/BUILD
@@ -212,6 +212,7 @@ nginx_suite(
         "check_with_token.t",
         "config_extra_field.t",
         "config_missing.t",
+        "config_rollouts_from_response.t",
         "config_rollouts_managed.t",
         "cors.t",
         "cors_disabled.t",

--- a/src/nginx/t/config_rollouts_from_response.t
+++ b/src/nginx/t/config_rollouts_from_response.t
@@ -1,0 +1,222 @@
+# Copyright (C) Extensible Service Proxy Authors
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+# OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+################################################################################
+#
+use strict;
+use warnings;
+use JSON::PP;
+use Data::Dumper;
+use Time::HiRes qw(usleep);
+
+################################################################################
+
+use src::nginx::t::ApiManager;    # Must be first (sets up import path to
+                                  # the Nginx test module)
+use src::nginx::t::HttpServer;
+use src::nginx::t::ServiceControl;
+use Test::Nginx;    # Imports Nginx's test module
+use Test::More;     # And the test framework
+
+################################################################################
+
+# Port assignments
+my $NginxPort          = ApiManager::pick_port();
+my $BackendPort        = ApiManager::pick_port();
+my $ServiceControlPort = ApiManager::pick_port();
+my $ServiceManagementPort = ApiManager::pick_port();
+
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(24);
+
+# Save service configuration that disables the report cache.
+# Report request will be sent for each client request
+$t->write_file_expand('server.pb.txt', <<"EOF");
+service_control_config {
+  report_aggregator_config {
+    cache_entries: 0
+    flush_interval_ms: 1000
+  }
+  check_aggregator_config {
+  	cache_entries: 0
+  	flush_interval_ms: 1000
+  }
+}
+service_management_config {
+  url: "http://127.0.0.1:${ServiceManagementPort}"
+  refresh_interval_ms: 100
+}
+service_config_rollout {
+  traffic_percentages { 
+    key: "%%TESTDIR%%/service.pb.txt"
+    value: 100
+  }
+  rollout_id: "2017-05-16r0"
+}
+rollout_strategy: "managed"
+EOF
+
+# Save service name in the service configuration protocol buffer file.
+$t->write_file( 'service.pb.txt',
+  ApiManager::get_bookstore_service_config . <<"EOF");
+control {
+  environment: "http://127.0.0.1:${ServiceControlPort}"
+}
+EOF
+
+ApiManager::write_file_expand( $t, 'nginx.conf', <<"EOF");
+%%TEST_GLOBALS%%
+daemon off;
+events {
+  worker_connections 32;
+}
+http {
+  %%TEST_GLOBALS_HTTP%%
+  server_tokens off;
+  server {
+    listen 127.0.0.1:${NginxPort};
+    server_name localhost;
+    location / {
+      endpoints {
+        server_config server.pb.txt;
+        %%TEST_CONFIG%%
+        on;
+      }
+      proxy_pass http://127.0.0.1:${BackendPort};
+    }
+    location /endpoints_status {
+      endpoints_status;
+      access_log off;
+    }
+  }
+}
+EOF
+
+my $report_done = 'report_done';
+my $rollout_done = 'rollout_done';
+
+$t->run_daemon( \&bookstore, $t, $BackendPort, 'bookstore.log' );
+$t->run_daemon( \&servicecontrol, $t, $ServiceControlPort, 'servicecontrol.log',
+  $report_done);
+$t->run_daemon( \&servicemanagement, $t, $ServiceManagementPort,
+  'servicemanagement.log', $rollout_done);
+  
+is( $t->waitforsocket("127.0.0.1:${BackendPort}"), 1, 'Bookstore socket ready.' );
+is( $t->waitforsocket("127.0.0.1:${ServiceControlPort}"), 1,
+  'Service control socket ready.' );
+is( $t->waitforsocket("127.0.0.1:${ServiceManagementPort}"), 1,
+  'Service management socket ready.' );
+$t->run();
+
+################################################################################
+
+for (my $count = 0 ; $count < 10 ; $count++) {
+    # send the request
+    my $response = ApiManager::http_get($NginxPort, '/shelves?key=this-is-an-api-key' );
+
+    # verify the response
+    my ( $response_headers, $response_body ) = split /\r\n\r\n/, $response, 2;
+    like( $response_headers, qr/HTTP\/1\.1 200 OK/, 'Returned HTTP 200.' );
+    is( $response_body, <<'EOF', 'Shelves returned in the response body.' );
+{ "shelves": [
+    { "name": "shelves/1", "theme": "Fiction" },
+    { "name": "shelves/2", "theme": "Fantasy" }
+  ]
+}
+EOF
+    # Refresh interval is 0.1s and 10 requests (with 0.1s sleep in between) are send,
+    # Refresh timer should have been called multiple times.
+    usleep(1000);
+}
+
+# Since Report response ID is set, serviemanagement server should not be called.
+my @servicemanagement_requests = ApiManager::read_http_stream( $t, 'servicemanagement.log' );
+is( scalar @servicemanagement_requests, 0, 'Service management is not called' );
+
+################################################################################
+
+sub bookstore {
+  my ( $t, $port, $file) = @_;
+  my $server = HttpServer->new( $port, $t->testdir() . '/' . $file )
+    or die "Can't create test server socket: $!\n";
+  local $SIG{PIPE} = 'IGNORE';
+  
+    $server->on_sub('POST', '/shelves?key=this-is-an-api-key', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+{ "shelves": [
+    { "name": "shelves/1", "theme": "Fiction" },
+    { "name": "shelves/2", "theme": "Fantasy" }
+  ]
+}
+EOF
+  });
+
+  $server->run();
+}
+
+sub servicecontrol {
+  my ( $t, $port, $file, $done) = @_;
+  my $server = HttpServer->new( $port, $t->testdir() . '/' . $file )
+    or die "Can't create test server socket: $!\n";
+  local $SIG{PIPE} = 'IGNORE';
+  
+  $server->on_sub('POST', '/v1/services/endpoints-test.cloudendpointsapis.com:check', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<'EOF';
+HTTP/1.1 200 OK
+Connection: close
+
+EOF
+  });
+
+  my $proto_response = ServiceControl::convert_proto(<<'EOF', 'report_response', 'binary');
+{
+  "serviceRolloutId": "2017-05-16r0"
+}
+EOF
+  $server->on_sub('POST', '/v1/services/endpoints-test.cloudendpointsapis.com:report', sub {
+    my ($headers, $body, $client) = @_;
+    print $client <<'EOF' . $proto_response;
+HTTP/1.1 200 OK
+Connection: close
+
+EOF
+  });
+
+  $server->run();
+}
+
+sub servicemanagement {
+  my ( $t, $port, $file) = @_;
+  my $server = HttpServer->new( $port, $t->testdir() . '/' . $file )
+    or die "Can't create test server socket: $!\n";
+  local $SIG{PIPE} = 'IGNORE';
+
+  $server->run();
+}
+
+################################################################################

--- a/src/nginx/t/config_rollouts_managed.t
+++ b/src/nginx/t/config_rollouts_managed.t
@@ -213,7 +213,7 @@ is($endpoints_status->{processes}[0]->{espStatus}[0]->{serviceConfigRollouts}->
     {rolloutId}, '2016-08-25r1',
     "Rollout was updated from the service management API" );
 is($endpoints_status->{processes}[0]->{espStatus}[0]->{serviceConfigRollouts}->
-    {percentages}->{'2016-08-25r3'}, '100', "Rollout 2016-08-25r3 is 10%" );
+    {percentages}->{'2016-08-25r3'}, '100', "Rollout 2016-08-25r3 is 100%" );
 
 $t->stop_daemons();
 


### PR DESCRIPTION
Now the Check/Report response has service_rollout_id.  It can be used to reduce the periodical ESP calls to service_management service to check the latest rollout ID.

The checking interval is 1 minute. During the checking interval, if the service_rollout_id from Check/Report response is the same as the current used one.  Not need to make a HTTP call.

