### PR TITLE
Fix grpc percent encode reserved code table

### DIFF
--- a/src/nginx/t/grpc_web_interop_status.t
+++ b/src/nginx/t/grpc_web_interop_status.t
@@ -126,7 +126,7 @@ $proto_request});
 verify_grpc_message("test", "test");
 verify_grpc_message(
 '\t\ntest with whitespace\r\nand Unicode BMP ☺ and non-BMP 😈\t\n',
-'%09%0Atest%20with%20whitespace%0D%0Aand%20Unicode%20BMP%20%E2%98%BA%20and%20non-BMP%20%F0%9F%98%88%09%0A');
+'%09%0Atest with whitespace%0D%0Aand Unicode BMP %E2%98%BA and non-BMP %F0%9F%98%88%09%0A');
 
 $t->stop_daemons();
 

--- a/src/nginx/util.cc
+++ b/src/nginx/util.cc
@@ -234,7 +234,7 @@ ngx_esp_header_iterator ngx_esp_header_iterator::operator++(int) {
 std::string grpc_percent_encode(const std::string &src) {
   grpc_slice in_slice = grpc_slice_from_static_buffer(src.data(), src.size());
   grpc_slice out_slice = grpc_percent_encode_slice(
-      in_slice, &grpc_url_percent_encoding_unreserved_bytes[0]);
+      in_slice, &grpc_compatible_percent_encoding_unreserved_bytes[0]);
   std::string out_str(
       reinterpret_cast<const char *>(GRPC_SLICE_START_PTR(out_slice)),
       GRPC_SLICE_LENGTH(out_slice));


### PR DESCRIPTION
According to https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md#responses

grpc percent encode reserved table is %x20-%x7E except "%".  So it should use grpc_compatible_percent_encoding_unreserved_bytes table


