### PR TITLE
Add service_agent and service_config_id to log_entries

### DIFF
--- a/src/api_manager/service_control/proto.cc
+++ b/src/api_manager/service_control/proto.cc
@@ -842,6 +842,8 @@ const char kLogFieldNameApiName[] = "api_name";
 const char kLogFieldNameApiVersion[] = "api_version";
 const char kLogFieldNameApiMethod[] = "api_method";
 const char kLogFieldNameApiKey[] = "api_key";
+const char kLogFieldNameConfigId[] = "service_config_id";
+const char kLogFieldNameProxyVersion[] = "proxy_version";
 const char kLogFieldNameProducerProjectId[] = "producer_project_id";
 const char kLogFieldNameReferer[] = "referer";
 const char kLogFieldNameLocation[] = "location";
@@ -906,6 +908,7 @@ void SetOperationCommonFields(const OperationInfo& info,
 }
 
 void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
+                  const std::string& config_id,
                   const Timestamp& current_time, LogEntry* log_entry) {
   log_entry->set_name(name);
   *log_entry->mutable_timestamp() = current_time;
@@ -917,6 +920,9 @@ void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
   (*fields)[kLogFieldNameTimestamp].set_number_value(
       (double)current_time.seconds() +
       (double)current_time.nanos() / (double)1000000000.0);
+  (*fields)[kLogFieldNameConfigId].set_string_value(config_id);
+  (*fields)[kLogFieldNameProxyVersion].set_string_value(
+      kServiceAgentPrefix + utils::Version::instance().get());
   if (!info.producer_project_id.empty()) {
     (*fields)[kLogFieldNameProducerProjectId].set_string_value(
         info.producer_project_id);
@@ -1176,7 +1182,7 @@ Status Proto::FillReportRequest(const ReportRequestInfo& info,
   // Fill log entries.
   if (info.is_final_report) {
     for (auto it = logs_.begin(), end = logs_.end(); it != end; it++) {
-      FillLogEntry(info, *it, current_time, op->add_log_entries());
+      FillLogEntry(info, *it, service_config_id_, current_time, op->add_log_entries());
     }
   }
 

--- a/src/api_manager/service_control/proto.cc
+++ b/src/api_manager/service_control/proto.cc
@@ -843,7 +843,7 @@ const char kLogFieldNameApiVersion[] = "api_version";
 const char kLogFieldNameApiMethod[] = "api_method";
 const char kLogFieldNameApiKey[] = "api_key";
 const char kLogFieldNameConfigId[] = "service_config_id";
-const char kLogFieldNameProxyVersion[] = "proxy_version";
+const char kLogFieldNameServiceAgent[] = "service_agent";
 const char kLogFieldNameProducerProjectId[] = "producer_project_id";
 const char kLogFieldNameReferer[] = "referer";
 const char kLogFieldNameLocation[] = "location";
@@ -908,8 +908,8 @@ void SetOperationCommonFields(const OperationInfo& info,
 }
 
 void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
-                  const std::string& config_id,
-                  const Timestamp& current_time, LogEntry* log_entry) {
+                  const std::string& config_id, const Timestamp& current_time,
+                  LogEntry* log_entry) {
   log_entry->set_name(name);
   *log_entry->mutable_timestamp() = current_time;
   auto severity = (info.response_code >= 400) ? google::logging::type::ERROR
@@ -921,7 +921,7 @@ void FillLogEntry(const ReportRequestInfo& info, const std::string& name,
       (double)current_time.seconds() +
       (double)current_time.nanos() / (double)1000000000.0);
   (*fields)[kLogFieldNameConfigId].set_string_value(config_id);
-  (*fields)[kLogFieldNameProxyVersion].set_string_value(
+  (*fields)[kLogFieldNameServiceAgent].set_string_value(
       kServiceAgentPrefix + utils::Version::instance().get());
   if (!info.producer_project_id.empty()) {
     (*fields)[kLogFieldNameProducerProjectId].set_string_value(
@@ -1182,7 +1182,8 @@ Status Proto::FillReportRequest(const ReportRequestInfo& info,
   // Fill log entries.
   if (info.is_final_report) {
     for (auto it = logs_.begin(), end = logs_.end(); it != end; it++) {
-      FillLogEntry(info, *it, service_config_id_, current_time, op->add_log_entries());
+      FillLogEntry(info, *it, service_config_id_, current_time,
+                   op->add_log_entries());
     }
   }
 

--- a/src/api_manager/service_control/testdata/final_report_request.golden
+++ b/src/api_manager/service_control/testdata/final_report_request.golden
@@ -543,6 +543,18 @@ operations {
           number_value: 1048576
         }
       }
+      fields {
+        key: "service_agent"
+        value {
+          string_value: "ESP/"
+        }
+      }
+      fields {
+        key: "service_config_id"
+        value {
+          string_value: "2016-09-19r0"
+        }
+      }
     }
     name: "local_test_log"
     timestamp {

--- a/src/api_manager/service_control/testdata/report_request.golden
+++ b/src/api_manager/service_control/testdata/report_request.golden
@@ -559,6 +559,18 @@ operations {
           number_value: 1048576
         }
       }
+      fields {
+        key: "service_agent"
+        value {
+          string_value: "ESP/"
+        }
+      }
+      fields {
+        key: "service_config_id"
+        value {
+          string_value: "2016-09-19r0"
+        }
+      }
     }
     name: "local_test_log"
     timestamp {

--- a/src/api_manager/service_control/testdata/report_request_by_consumer.golden
+++ b/src/api_manager/service_control/testdata/report_request_by_consumer.golden
@@ -559,6 +559,18 @@ operations {
           number_value: 1048576
         }
       }
+      fields {
+        key: "service_agent"
+        value {
+          string_value: "ESP/"
+        }
+      }
+      fields {
+        key: "service_config_id"
+        value {
+          string_value: "2016-09-19r0"
+        }
+      }
     }
     name: "local_test_log"
     timestamp {

--- a/src/api_manager/service_control/testdata/report_request_empty_optional.golden
+++ b/src/api_manager/service_control/testdata/report_request_empty_optional.golden
@@ -79,6 +79,18 @@ operations {
           string_value: "project_id"
         }
       }
+      fields {
+        key: "service_agent"
+        value {
+          string_value: "ESP/"
+        }
+      }
+      fields {
+        key: "service_config_id"
+        value {
+          string_value: "2016-09-19r0"
+        }
+      }
     }
     name: "local_test_log"
     timestamp {

--- a/src/api_manager/service_control/testdata/report_request_failed.golden
+++ b/src/api_manager/service_control/testdata/report_request_failed.golden
@@ -353,6 +353,18 @@ operations {
           number_value: 1048576
         }
       }
+      fields {
+        key: "service_agent"
+        value {
+          string_value: "ESP/"
+        }
+      }
+      fields {
+        key: "service_config_id"
+        value {
+          string_value: "2016-09-19r0"
+        }
+      }
     }
     name: "local_test_log"
     timestamp {

--- a/src/nginx/t/ServiceControl.pm
+++ b/src/nginx/t/ServiceControl.pm
@@ -165,6 +165,8 @@ sub gen_log_entry {
     'http_response_code' => $in->{response_code},
   };
 
+  $payload->{service_agent} = service_agent();
+  $payload->{service_config_id} = $in->{serviceConfigId} if exists $in->{serviceConfigId};
   $payload->{api_method} = $in->{api_method} if exists $in->{api_method};
   $payload->{api_name} = $in->{api_name} if exists $in->{api_name};
   $payload->{api_version} = $in->{api_version} if exists $in->{api_version};

--- a/src/nginx/t/grpc_api_key.t
+++ b/src/nginx/t/grpc_api_key.t
@@ -124,6 +124,7 @@ like($r->{uri}, qr/:report$/, 'Second call was a :report');
 
 my $report_body = ServiceControl::convert_proto($r->{body}, 'report_request', 'json');
 my $expected_report_body = ServiceControl::gen_report_body({
+  'serviceConfigId' => '2016-08-25r1',
   'serviceName' =>  'endpoints-grpc-test.cloudendpointsapis.com',
   'api_method' => 'test.grpc.Test.Echo',
   'url' => '/test.grpc.Test/Echo',

--- a/src/nginx/t/grpc_compression.t
+++ b/src/nginx/t/grpc_compression.t
@@ -125,6 +125,7 @@ like($r->{uri}, qr/:report$/, 'Second call was a :report');
 
 my $report_body = ServiceControl::convert_proto($r->{body}, 'report_request', 'json');
 my $expected_report_body = ServiceControl::gen_report_body({
+  'serviceConfigId' => '2016-08-25r1',
   'serviceName' =>  'endpoints-grpc-test.cloudendpointsapis.com',
   'api_method' => 'test.grpc.Test.Echo',
   'url' => '/test.grpc.Test/Echo',

--- a/src/nginx/t/grpc_streaming.t
+++ b/src/nginx/t/grpc_streaming.t
@@ -127,6 +127,7 @@ like($r->{uri}, qr/:report$/, 'Second call was a :report');
 
 my $report_body = ServiceControl::convert_proto($r->{body}, 'report_request', 'json');
 my $expected_report_body = ServiceControl::gen_report_body({
+  'serviceConfigId' => '2016-08-25r1',
   'serviceName' =>  'endpoints-grpc-test.cloudendpointsapis.com',
   'api_method' =>  'test.grpc.Test.EchoStream',
   'url' => '/test.grpc.Test/EchoStream',

--- a/src/nginx/t/grpc_uds.t
+++ b/src/nginx/t/grpc_uds.t
@@ -124,6 +124,7 @@ like($r->{uri}, qr/:report$/, 'Second call was a :report');
 
 my $report_body = ServiceControl::convert_proto($r->{body}, 'report_request', 'json');
 my $expected_report_body = ServiceControl::gen_report_body({
+  'serviceConfigId' => '2016-08-25r1',
   'serviceName' =>  'endpoints-grpc-test.cloudendpointsapis.com',
   'api_method' => 'test.grpc.Test.Echo',
   'url' => '/test.grpc.Test/Echo',

--- a/src/nginx/t/multiple_apis.t
+++ b/src/nginx/t/multiple_apis.t
@@ -232,7 +232,9 @@ my $expected_report_body = {
       'http_response_code' => 200,
       'request_size_in_bytes' => 55,
       'response_size_in_bytes' =>  90,
-      'http_method' => 'GET'
+      'http_method' => 'GET',
+      'service_agent' => ServiceControl::service_agent(),
+      'service_config_id' => '2016-08-25r1'
      },
      'name' => 'endpoints_log',
      'severity' => 'INFO'

--- a/src/nginx/t/testdata/grpc_echo_service.pb.txt
+++ b/src/nginx/t/testdata/grpc_echo_service.pb.txt
@@ -1,6 +1,7 @@
 name: "endpoints-grpc-test.cloudendpointsapis.com"
 producer_project_id: "endpoints-grpc-test"
 title: "GRPC Echo Test"
+id: "2016-08-25r1"
 apis {
   name: "test.grpc.Test"
   methods {


### PR DESCRIPTION

So querying endpoint log, publishers can find out ESP version and service config id used for each request.
It will be useful for debugging.