### PR TITLE
Second try to fix flaky config_rollout_from_response test

### DIFF
--- a/include/api_manager/api_manager.h
+++ b/include/api_manager/api_manager.h
@@ -43,6 +43,11 @@ struct ServiceConfigRolloutsInfo {
   // Maps service configuration IDs to their corresponding traffic percentage.
   // Key is the service configuration ID, Value is the traffic percentage
   std::map<std::string, int> percentages;
+
+  // number of remote calls to check the rollout_id
+  uint64_t remote_rollout_calls;
+  // number of skipped calls by using response rollout_id
+  uint64_t skipped_rollout_calls;
 };
 
 class ApiManager {

--- a/src/api_manager/api_manager_impl.cc
+++ b/src/api_manager/api_manager_impl.cc
@@ -290,6 +290,16 @@ utils::Status ApiManagerImpl::GetServiceConfigRollouts(
     rollouts->percentages[item.first] = item.second;
   }
 
+  if (config_manager_) {
+    rollouts->remote_rollout_calls =
+        config_manager_->get_remote_rollout_calls();
+    rollouts->skipped_rollout_calls =
+        config_manager_->get_skipped_rollout_calls();
+  } else {
+    rollouts->remote_rollout_calls = 0;
+    rollouts->skipped_rollout_calls = 0;
+  }
+
   return utils::Status::OK;
 }
 

--- a/src/api_manager/config_manager.h
+++ b/src/api_manager/config_manager.h
@@ -90,6 +90,9 @@ class ConfigManager {
     }
   }
 
+  uint64_t get_remote_rollout_calls() const { return remote_rollout_calls_; }
+  uint64_t get_skipped_rollout_calls() const { return skipped_rollout_calls_; }
+
  private:
   // Fetch the latest rollouts
   void FetchRollouts();
@@ -115,6 +118,10 @@ class ConfigManager {
   std::string current_rollout_id_;
   // Time based window request counter
   std::unique_ptr<utils::TimeBasedCounter> window_request_counter_;
+  // number of remote calls to check the rollout_id
+  uint64_t remote_rollout_calls_{};
+  // number of skipped calls by using response rollout_id
+  uint64_t skipped_rollout_calls_{};
 };
 
 }  // namespace api_manager

--- a/src/api_manager/proto/api_manager_status.proto
+++ b/src/api_manager/proto/api_manager_status.proto
@@ -49,8 +49,17 @@ message ServiceControlStatistics {
 // Maps service configuration IDs to their corresponding traffic percentage.
 // Key is the service configuration ID, Value is the traffic percentage
 message ServiceConfigRollouts {
+  // Current rollout id
   string rollout_id = 1;
+
+  // map of service config id to its traffic percentage.
   map<string, uint64> percentages = 2;
+
+  // number of remote calls to check the rollout_id
+  uint64 remote_rollout_calls = 3;
+
+  // number of skipped calls by using response rollout_id
+  uint64 skipped_rollout_calls = 4;
 }
 
 // Status for ESP instances

--- a/src/nginx/status.cc
+++ b/src/nginx/status.cc
@@ -300,6 +300,8 @@ ngx_int_t ngx_esp_update_rollout(std::shared_ptr<ApiManager> esp,
   for (auto percentage : rollouts_info.percentages) {
     (*new_rollouts.mutable_percentages())[percentage.first] = percentage.second;
   }
+  new_rollouts.set_remote_rollout_calls(rollouts_info.remote_rollout_calls);
+  new_rollouts.set_skipped_rollout_calls(rollouts_info.skipped_rollout_calls);
 
   int length = new_rollouts.ByteSize();
   if (0 < length && length <= kMaxServiceRolloutsInfoSize) {


### PR DESCRIPTION

Previous using number of actual calls to fake service_managment server is not stable. 
Instead adding some statistics to keep track of rollout calls.  and use the skipped_rollout_calls status
