### PR TITLE
Set grpc.max_metadata_size to INT_MAX

### DIFF
--- a/src/nginx/grpc.cc
+++ b/src/nginx/grpc.cc
@@ -134,6 +134,7 @@ std::pair<Status, std::shared_ptr<::grpc::GenericStub>> GrpcGetStub(
 
   channel_arguments.SetMaxReceiveMessageSize(INT_MAX);
   channel_arguments.SetMaxSendMessageSize(INT_MAX);
+  channel_arguments.SetInt(GRPC_ARG_MAX_METADATA_SIZE, INT_MAX);
 
   auto result =
       std::make_shared<::grpc::GenericStub>(::grpc::CreateCustomChannel(

--- a/test/transcoding/bookstore-server.cc
+++ b/test/transcoding/bookstore-server.cc
@@ -175,7 +175,8 @@ class BookstoreServiceImpl : public Bookstore::Service {
 
     ShelfNotFoundDetail custom_pb;
     custom_pb.set_for_shelf_id(id);
-    custom_pb.set_why("Custom detail: shell not found");
+    // Set 200KB details to test grpc.max_metadata_size
+    custom_pb.set_why(std::string(200 * 1024, 'c') + "Custom detail: shell not found");
     rpc_status.add_details()->PackFrom(custom_pb);
 
     return ::grpc::Status(grpc::NOT_FOUND,

--- a/test/transcoding/bookstore-server.cc
+++ b/test/transcoding/bookstore-server.cc
@@ -176,7 +176,8 @@ class BookstoreServiceImpl : public Bookstore::Service {
     ShelfNotFoundDetail custom_pb;
     custom_pb.set_for_shelf_id(id);
     // Set 200KB details to test grpc.max_metadata_size
-    custom_pb.set_why(std::string(200 * 1024, 'c') + "Custom detail: shell not found");
+    custom_pb.set_why(std::string(200 * 1024, 'c') +
+                      "Custom detail: shell not found");
     rpc_status.add_details()->PackFrom(custom_pb);
 
     return ::grpc::Status(grpc::NOT_FOUND,


### PR DESCRIPTION

When ESP creates grpc channel, need to increase grpc.max_metadata_size. This PR set it to INT_MAX

https://github.com/cloudendpoints/esp/issues/618