### PR TITLE
Changed e2e tests to use new secret files

### DIFF
--- a/script/all-utilities
+++ b/script/all-utilities
@@ -149,7 +149,7 @@ function retry() {
 # Download api Keys from Cloud storage and source the file.
 function set_api_keys() {
   local api_key_directory="$(mktemp -d)"
-  $GSUTIL cp gs://client-secret-files/api_keys \
+  $GSUTIL cp gs://esp-testing-secret-files/api_keys \
         "${api_key_directory}/api_keys" \
           || error_exit "Failed to download API key file."
 
@@ -160,7 +160,7 @@ function set_api_keys() {
 function get_test_client_key() {
   local key_path=$1
   [[ -e $key_path ]] || $GSUTIL \
-    cp gs://client-secret-files/esp-test-client-434d3cb34a1c.json $key_path
+    cp gs://esp-testing-secret-files/esp-load-test-82cfd7979030.json $key_path
   echo -n $key_path
   return 0
 }
@@ -280,11 +280,11 @@ function activate_service_account() {
   local local_json="$(mktemp /tmp/XXXXXX.secret.json)"
   case "${project}" in
     esp-load-test)
-      remote_json_name='esp-load-test-08fcbb64ace1.json'
+      remote_json_name='esp-load-test-82cfd7979030.json'
       service_account='service-control-in-load-test@esp-load-test.iam.gserviceaccount.com'
       ;;
     esp-long-run)
-      remote_json_name='esp-long-run-f92945d40e0b.json'
+      remote_json_name='esp-long-run-4f1701e6f180.json'
       service_account='deploy-esp-vm@esp-long-run.iam.gserviceaccount.com'
       ;;
     *)
@@ -294,7 +294,7 @@ function activate_service_account() {
   esac
   echo "Downloading ${project} service account"
   retry -n 5 -s 10 gsutil cp \
-    "gs://client-secret-files/${remote_json_name}" "${local_json}" \
+    "gs://esp-testing-secret-files/${remote_json_name}" "${local_json}" \
     || error_exit "Could not download secret keys for ${project}"
   echo "Gcloud auth activate ${project} service account."
   retry -n 2 ${GCLOUD} auth activate-service-account --key-file "${local_json}" \

--- a/script/all-utilities
+++ b/script/all-utilities
@@ -160,7 +160,7 @@ function set_api_keys() {
 function get_test_client_key() {
   local key_path=$1
   [[ -e $key_path ]] || $GSUTIL \
-    cp gs://esp-testing-secret-files/esp-load-test-82cfd7979030.json $key_path
+    cp gs://esp-testing-secret-files/esp-test-client-b1289e36f3df.json $key_path
   echo -n $key_path
   return 0
 }

--- a/script/linux-start-local-test
+++ b/script/linux-start-local-test
@@ -66,7 +66,7 @@ ${SUDO} sh -c 'echo "1024 65000" > /proc/sys/net/ipv4/ip_local_port_range'
 
 NGINX=${ROOT}/nginx-esp
 
-gsutil cp gs://client-secret-files/esp-load-test-08fcbb64ace1.json \
+gsutil cp gs://esp-testing-secret-files/esp-load-test-82cfd7979030.json \
     "${ROOT}/test/echo/gce-vm/client-secret.json" \
   || error_exit "Failed to download credentials."
 

--- a/script/linux-test-kb-long-run
+++ b/script/linux-test-kb-long-run
@@ -58,7 +58,7 @@ fi
 # Download api Keys with restrictions from Cloud storage.
 TEMP_DIR="$(mktemp -d)"
 API_RESTRICTION_KEYS_FILE="${TEMP_DIR}/esp-e2e-key-restriction.json"
-gsutil cp gs://client-secret-files/esp-e2e-key-restriction.json \
+gsutil cp gs://esp-testing-secret-files/esp-e2e-key-restriction.json \
       "${API_RESTRICTION_KEYS_FILE}" \
         || error_exit "Failed to download API key with restrictions file."
 


### PR DESCRIPTION
The old secret files in client-secret-files bucket was removed by someone. The new secret files were re-created and uploaded to a new bucket