### PR TITLE
Fix crash: Not to free timer object in the timer callback function

### DIFF
--- a/include/api_manager/env_interface.h
+++ b/include/api_manager/env_interface.h
@@ -49,6 +49,9 @@ class ApiManagerEnvInterface {
 
   // Simple periodic timer support. API Manager uses this method to get
   // called at regular intervals of wall-clock time.
+  // Warning: the returned timer object should NOT be destroyed at callback
+  // function. Otherwise it will cause segfault since Nginx is reading its
+  // data after the callback.
   virtual std::unique_ptr<PeriodicTimer> StartPeriodicTimer(
       std::chrono::milliseconds interval,
       std::function<void()> continuation) = 0;

--- a/include/api_manager/periodic_timer.h
+++ b/include/api_manager/periodic_timer.h
@@ -34,6 +34,9 @@ class PeriodicTimer {
   // synchronize with outstanding invocations of the timer's callback
   // function; it may be invoked from within the callback.
   virtual void Stop() = 0;
+
+  // The timer is stopped
+  virtual bool IsStopped() const = 0;
 };
 
 }  // namespace api_manager

--- a/src/api_manager/api_manager_test.cc
+++ b/src/api_manager/api_manager_test.cc
@@ -201,22 +201,6 @@ const char kServiceForStatistics[] =
     "  environment: \"http://127.0.0.1:8081\"\n"
     "}\n";
 
-// Simulate periodic timer event on creation
-class MockPeriodicTimer : public PeriodicTimer {
- public:
-  MockPeriodicTimer() {}
-  MockPeriodicTimer(std::function<void()> continuation)
-      : continuation_(continuation) {}
-
-  virtual ~MockPeriodicTimer() {}
-  void Stop(){};
-
-  void Run() { continuation_(); }
-
- private:
-  std::function<void()> continuation_;
-};
-
 class MockTimerApiManagerEnvironment : public MockApiManagerEnvironment {
  public:
   MOCK_METHOD2(Log, void(LogLevel, const char *));

--- a/src/api_manager/config_manager.cc
+++ b/src/api_manager/config_manager.cc
@@ -44,6 +44,9 @@ ConfigManager::ConfigManager(
                                         .fetch_throttle_window_s();
     }
   }
+  static std::random_device random_device;
+  random_generator_.seed(random_device());
+
   // throttle in milliseconds
   random_dist_.reset(new std::uniform_int_distribution<int>(
       0, fetch_throttle_window_in_s_ * 1000));
@@ -64,8 +67,8 @@ void ConfigManager::SetLatestRolloutId(
     return;
   }
 
-  // Timer is pending, or too close to last fetch time
-  if (fetch_timer_ || now < next_window_time_) {
+  // Last timer is not fired yet,  or is too close to last fetch time
+  if ((fetch_timer_ && !fetch_timer_->IsStopped()) || now < next_window_time_) {
     return;
   }
 
@@ -79,9 +82,7 @@ void ConfigManager::SetLatestRolloutId(
 
 void ConfigManager::OnRolloutsRefreshTimer() {
   global_context_->env()->LogInfo("Fetch timer starts");
-
   fetch_timer_->Stop();
-  fetch_timer_ = nullptr;
   next_window_time_ = std::chrono::system_clock::now() +
                       std::chrono::seconds(fetch_throttle_window_in_s_);
 

--- a/src/api_manager/context/BUILD
+++ b/src/api_manager/context/BUILD
@@ -44,6 +44,7 @@ cc_library(
         "//external:service_config",
         "//external:servicecontrol",
         "//external:servicecontrol_client",
+        "//src/api_manager:compute_platform",
         "//src/api_manager:http_template",
         "//src/api_manager:impl_headers",
         "//src/api_manager:path_matcher",
@@ -52,7 +53,6 @@ cc_library(
         "//src/api_manager/auth:authz",
         "//src/api_manager/auth:service_account_token",
         "//src/api_manager/cloud_trace",
-        "//src/api_manager:compute_platform",
         "//src/api_manager/service_control",
         "//src/api_manager/utils",
     ],
@@ -67,6 +67,7 @@ cc_test(
     deps = [
         "//external:googletest_main",
         "//src/api_manager",
+        "//src/api_manager:mock_api_manager_environment",
     ],
 )
 

--- a/src/api_manager/context/client_ip_extraction_test.cc
+++ b/src/api_manager/context/client_ip_extraction_test.cc
@@ -22,9 +22,9 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
-//#include "src/api_manager/mock_api_manager_environment.h"
 #include "src/api_manager/context/request_context.h"
 #include "src/api_manager/context/service_context.h"
+#include "src/api_manager/mock_api_manager_environment.h"
 //#include "src/api_manager/mock_request.h"
 //#include "src/api_manager/api_manager_impl.h"
 #include "include/api_manager/request.h"
@@ -69,22 +69,6 @@ const char kServiceConfig1[] =
   "id": "2017-05-01r0"
 }
 )";
-
-// Simulate periodic timer event on creation
-class MockPeriodicTimer : public PeriodicTimer {
- public:
-  MockPeriodicTimer() {}
-  MockPeriodicTimer(std::function<void()> continuation)
-      : continuation_(continuation) {
-    continuation_();
-  }
-
-  virtual ~MockPeriodicTimer() {}
-  void Stop() {}
-
- private:
-  std::function<void()> continuation_;
-};
 
 class MockApiManagerEnvironment : public ApiManagerEnvInterface {
  public:

--- a/src/api_manager/mock_api_manager_environment.h
+++ b/src/api_manager/mock_api_manager_environment.h
@@ -21,6 +21,24 @@
 namespace google {
 namespace api_manager {
 
+// Represents a periodic timer created by API Manager's environment.
+class MockPeriodicTimer : public PeriodicTimer {
+ public:
+  MockPeriodicTimer() {}
+  MockPeriodicTimer(std::function<void()> continuation)
+      : continuation_(continuation) {}
+
+  virtual ~MockPeriodicTimer() {}
+  void Stop() override { stopped_ = true; };
+  bool IsStopped() const override { return stopped_; }
+
+  void Run() { continuation_(); }
+
+ private:
+  bool stopped_{};
+  std::function<void()> continuation_;
+};
+
 class MockApiManagerEnvironment : public ApiManagerEnvInterface {
  public:
   MOCK_METHOD2(Log, void(LogLevel, const char *));

--- a/src/api_manager/rewrite_rule_test.cc
+++ b/src/api_manager/rewrite_rule_test.cc
@@ -46,22 +46,6 @@ std::string kExpectedRewriteErrorLog =
 std::string kExpectedNotInitializedLog =
     "INFO Rewrite rule was not initialized";
 
-// Simulate periodic timer event on creation
-class MockPeriodicTimer : public PeriodicTimer {
- public:
-  MockPeriodicTimer() {}
-  MockPeriodicTimer(std::function<void()> continuation)
-      : continuation_(continuation) {
-    continuation_();
-  }
-
-  virtual ~MockPeriodicTimer() {}
-  void Stop(){};
-
- private:
-  std::function<void()> continuation_;
-};
-
 class MockTimerApiManagerEnvironment : public MockApiManagerEnvironmentWithLog {
  public:
   void Log(LogLevel level, const char *message) {

--- a/src/nginx/environment.cc
+++ b/src/nginx/environment.cc
@@ -93,6 +93,8 @@ void NgxEspTimer::OnExpiration(ngx_event_t *ev) {
   }
   NgxEspTimer *t = reinterpret_cast<NgxEspTimer *>(ev->data);
   t->callback_();
+  // Warning: the timer object should not be freed in the above
+  // callback function. Otherwise the next line will use freed memory.
   if (!t->stopped_) {
     t->AddTimer();
   }

--- a/src/nginx/environment.h
+++ b/src/nginx/environment.h
@@ -67,7 +67,9 @@ class NgxEspTimer : public PeriodicTimer {
 
   virtual ~NgxEspTimer();
 
-  virtual void Stop();
+  void Stop() override;
+
+  bool IsStopped() const override { return stopped_; }
 
  private:
   void AddTimer();

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -604,7 +604,7 @@ config file.'''.format(
         help='''Enable HSTS (HTTP Strict Transport Security).
         ''')
 
-    parser.add_argument('--enable_debug', action='store_true',
+    parser.add_argument('--enable_debug', default=True, action='store_true',
         help='''Run debug Nginx binary with debug trace.
         ''')
 

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -604,7 +604,7 @@ config file.'''.format(
         help='''Enable HSTS (HTTP Strict Transport Security).
         ''')
 
-    parser.add_argument('--enable_debug', default=True, action='store_true',
+    parser.add_argument('--enable_debug', action='store_true',
         help='''Run debug Nginx binary with debug trace.
         ''')
 


### PR DESCRIPTION
NgxEspPeriodical timer object should not be freed in the timer callback function since Nginx is reading its data after the callback.

https://github.com/cloudendpoints/esp/pull/654  used that timer object as one time timer.  and free the object inside the callback fuction which cause the segment.

This changes:
* not to free the object,  only call stop, and wait for next time to override it
* add a new function IsStopped() to check if timer is still active
* Moved multiple MockPeriodTimer object into one place.
* Also seed the random generator.
