### PR TITLE
not to overwrite same config_id

### DIFF
--- a/src/api_manager/api_manager_impl.cc
+++ b/src/api_manager/api_manager_impl.cc
@@ -166,6 +166,11 @@ utils::Status ApiManagerImpl::AddConfig(const std::string &service_config,
 
   *config_id = config->service().id();
 
+  // If the config_id is already created, not to over-write, just use it.
+  if (service_context_map_.find(*config_id) != service_context_map_.end()) {
+    return utils::Status::OK;
+  }
+
   auto context_service = std::make_shared<context::ServiceContext>(
       global_context_, std::move(config));
   if (initialize == true && context_service->service_control()) {


### PR DESCRIPTION
Such over-write will cause crash: the old object is released, but it may be used in async remote Check or Report call.  When the callback is called, it will use the freed object.

This will happen when: ESP starts with a service config with ID=A,  but rollout ID is unknown, or empty.  
When the a new rollout is detected,  fetching the config with the same ID=A,  it will over-write the old one.  It will cause crash

This crash bug exists long time ago. The trigger condition is:  --rollout_strategy=managed and --version is also set.  In this case, start_esp only fetch the specific version, set rollout_id to empty. 1 minutes after ESP started, it checks latest rollout, and fetch the config with same id, and replace the new ServiceContext with the old one.   If there are some on-going traffic using the old ServiceContext, it will cause the crash since the old ServiceContext is deleted. 