### PR TITLE
Escape query parameters in backend_routing

### DIFF
--- a/include/api_manager/method.h
+++ b/include/api_manager/method.h
@@ -113,8 +113,8 @@ class MethodInfo {
   virtual const std::vector<std::pair<std::string, int>> &metric_cost_vector()
       const = 0;
 
-  // If true, binding value should be url escaped.
-  virtual bool escape_binding() const = 0;
+  // If true, binding should remain url escaped.
+  virtual bool keep_binding_escaped() const = 0;
 };
 
 }  // namespace api_manager

--- a/include/api_manager/method.h
+++ b/include/api_manager/method.h
@@ -112,6 +112,9 @@ class MethodInfo {
   // Get quota metric cost vector
   virtual const std::vector<std::pair<std::string, int>> &metric_cost_vector()
       const = 0;
+
+  // If true, binding value should be url escaped.
+  virtual bool escape_binding() const = 0;
 };
 
 }  // namespace api_manager

--- a/src/api_manager/method_impl.h
+++ b/src/api_manager/method_impl.h
@@ -155,7 +155,7 @@ class MethodInfoImpl : public MethodInfo {
   void ProcessSystemQueryParameterNames();
 
   bool escape_binding() const override {
-    // Variable bindings normaly are used for grpc transcoding.
+    // Variable bindings normally are used for grpc transcoding.
     // Their values should be un-escaped.
     // But for CONSTANT_ADDRESS bakend path translation,
     // they are used to re-format the URL path: from path segments

--- a/src/api_manager/method_impl.h
+++ b/src/api_manager/method_impl.h
@@ -154,6 +154,16 @@ class MethodInfoImpl : public MethodInfo {
 
   void ProcessSystemQueryParameterNames();
 
+  bool escape_binding() const override {
+    // Variable bindings normaly are used for grpc transcoding.
+    // Their values should be un-escaped.
+    // But for CONSTANT_ADDRESS bakend path translation,
+    // they are used to re-format the URL path: from path segments
+    // to query parameters. They should remain escaped.
+    return backend_path_translation() ==
+           ::google::api::BackendRule_PathTranslation_CONSTANT_ADDRESS;
+  }
+
  private:
   struct AuthProvider {
     std::set<std::string> audiences;

--- a/src/api_manager/method_impl.h
+++ b/src/api_manager/method_impl.h
@@ -157,7 +157,7 @@ class MethodInfoImpl : public MethodInfo {
   bool escape_binding() const override {
     // Variable bindings normally are used for grpc transcoding.
     // Their values should be un-escaped.
-    // But for CONSTANT_ADDRESS bakend path translation,
+    // But for CONSTANT_ADDRESS backend path translation,
     // they are used to re-format the URL path: from path segments
     // to query parameters. They should remain escaped.
     return backend_path_translation() ==

--- a/src/api_manager/method_impl.h
+++ b/src/api_manager/method_impl.h
@@ -154,12 +154,12 @@ class MethodInfoImpl : public MethodInfo {
 
   void ProcessSystemQueryParameterNames();
 
-  bool escape_binding() const override {
+  bool keep_binding_escaped() const override {
     // Variable bindings normally are used for grpc transcoding.
     // Their values should be un-escaped.
     // But for CONSTANT_ADDRESS backend path translation,
     // they are used to re-format the URL path: from path segments
-    // to query parameters. They should remain escaped.
+    // to query parameters. Their values should keep as escaped.
     return backend_path_translation() ==
            ::google::api::BackendRule_PathTranslation_CONSTANT_ADDRESS;
   }

--- a/src/api_manager/path_matcher.h
+++ b/src/api_manager/path_matcher.h
@@ -249,7 +249,8 @@ std::string UrlUnescapeString(const std::string& part,
 template <class VariableBinding>
 void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
                              const std::vector<std::string>& parts,
-                             std::vector<VariableBinding>* bindings) {
+                             std::vector<VariableBinding>* bindings,
+                             bool escape_binding) {
   for (const auto& var : vars) {
     // Determine the subpath bound to the variable based on the
     // [start_segment, end_segment) segment range of the variable.
@@ -269,8 +270,12 @@ void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
         (end_segment - var.start_segment) > 1 || var.end_segment < 0;
     // Joins parts with "/"  to form a path string.
     for (size_t i = var.start_segment; i < end_segment; ++i) {
-      // For multipart matches only unescape non-reserved characters.
-      binding.value += UrlUnescapeString(parts[i], !is_multipart);
+      if (escape_binding) {
+        binding.value += parts[i];
+      } else {
+        // For multipart matches only unescape non-reserved characters.
+        binding.value += UrlUnescapeString(parts[i], !is_multipart);
+      }
       if (i < end_segment - 1) {
         binding.value += "/";
       }
@@ -282,7 +287,7 @@ void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
 template <class VariableBinding>
 void ExtractBindingsFromQueryParameters(
     const std::string& query_params, const std::set<std::string>& system_params,
-    std::vector<VariableBinding>* bindings) {
+    std::vector<VariableBinding>* bindings, bool escape_binding) {
   // The bindings in URL the query parameters have the following form:
   //      <field_path1>=value1&<field_path2>=value2&...&<field_pathN>=valueN
   // Query parameters may also contain system parameters such as `api_key`.
@@ -302,7 +307,11 @@ void ExtractBindingsFromQueryParameters(
         // in the request, e.g. `book.author.name`.
         VariableBinding binding;
         split(name, '.', binding.field_path);
-        binding.value = UrlUnescapeString(param.substr(pos + 1), true);
+        if (escape_binding) {
+          binding.value = param.substr(pos + 1);
+        } else {
+          binding.value = UrlUnescapeString(param.substr(pos + 1), true);
+        }
         bindings->emplace_back(std::move(binding));
       }
     }
@@ -413,10 +422,12 @@ Method PathMatcher<Method>::Lookup(
   MethodData* method_data = reinterpret_cast<MethodData*>(lookup_result.data);
   if (variable_bindings != nullptr) {
     variable_bindings->clear();
-    ExtractBindingsFromPath(method_data->variables, parts, variable_bindings);
+    bool escape_binding = method_data->method->escape_binding();
+    ExtractBindingsFromPath(method_data->variables, parts, variable_bindings,
+                            escape_binding);
     ExtractBindingsFromQueryParameters(
         query_params, method_data->method->system_query_parameter_names(),
-        variable_bindings);
+        variable_bindings, escape_binding);
   }
   if (body_field_path != nullptr) {
     *body_field_path = method_data->body_field_path;

--- a/src/api_manager/path_matcher_test.cc
+++ b/src/api_manager/path_matcher_test.cc
@@ -24,6 +24,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+using ::testing::NiceMock;
+using ::testing::Return;
 using ::testing::ReturnRef;
 
 namespace google {
@@ -50,6 +52,7 @@ class MethodInfo {
  public:
   MOCK_CONST_METHOD0(system_query_parameter_names,
                      const std::set<std::string>&());
+  MOCK_CONST_METHOD0(escape_binding, bool());
 };
 
 bool operator==(const Binding& b1, const Binding& b2) {
@@ -65,9 +68,19 @@ class PathMatcherTest : public ::testing::Test {
                                        std::string http_template,
                                        std::string body_field_path,
                                        std::string expected_error) {
-    auto method = new MethodInfo();
+    return AddPathWithBodyFieldPathEscape(
+        http_method, http_template, body_field_path, expected_error, false);
+  }
+
+  MethodInfo* AddPathWithBodyFieldPathEscape(std::string http_method,
+                                             std::string http_template,
+                                             std::string body_field_path,
+                                             std::string expected_error,
+                                             bool escape_binding) {
+    auto method = new NiceMock<MethodInfo>();
     ON_CALL(*method, system_query_parameter_names())
         .WillByDefault(ReturnRef(empty_set_));
+    ON_CALL(*method, escape_binding()).WillByDefault(Return(escape_binding));
     auto status =
         builder_.Register(http_method, http_template, body_field_path, method);
     if (!status.ok()) {
@@ -84,9 +97,10 @@ class PathMatcherTest : public ::testing::Test {
   MethodInfo* AddPathWithSystemParams(
       std::string http_method, std::string http_template,
       const std::set<std::string>* system_params) {
-    auto method = new MethodInfo();
+    auto method = new NiceMock<MethodInfo>();
     ON_CALL(*method, system_query_parameter_names())
         .WillByDefault(ReturnRef(*system_params));
+    ON_CALL(*method, escape_binding()).WillByDefault(Return(false));
     if (!builder_.Register(http_method, http_template, std::string(), method)
              .ok()) {
       delete method;
@@ -136,7 +150,7 @@ class PathMatcherTest : public ::testing::Test {
  private:
   PathMatcherBuilder<MethodInfo*> builder_;
   PathMatcherPtr<MethodInfo*> matcher_;
-  std::vector<std::unique_ptr<MethodInfo>> stored_methods_;
+  std::vector<std::unique_ptr<NiceMock<MethodInfo>>> stored_methods_;
   std::set<std::string> empty_set_;
 };
 
@@ -291,6 +305,21 @@ TEST_F(PathMatcherTest, PercentEscapesUnescapedForSingleSegment) {
   EXPECT_EQ(Lookup("GET", "/a/p%20q%2Fr/c", &bindings), a_c);
   EXPECT_EQ(Bindings({
                 Binding{FieldPath{"x"}, "p q/r"},
+            }),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, PercentEscapedForSingleSegment) {
+  MethodInfo* a_c =
+      AddPathWithBodyFieldPathEscape("GET", "/a/{x}/c", "", "", true);
+  Build();
+
+  EXPECT_NE(nullptr, a_c);
+
+  Bindings bindings;
+  EXPECT_EQ(Lookup("GET", "/a/p%20q%2Fr/c", &bindings), a_c);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "p%20q%2Fr"},
             }),
             bindings);
 }
@@ -731,7 +760,7 @@ TEST_F(PathMatcherTest, VariableBindingsWithQueryParams) {
             bindings);
 }
 
-TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsEncoding) {
+TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsEncodingNoEscape) {
   MethodInfo* a = AddGetPath("/a");
   Build();
 
@@ -747,6 +776,26 @@ TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsEncoding) {
   EXPECT_EQ(LookupWithParams("GET", "/a", "x=%24%25%2F%20%0A", &bindings), a);
   EXPECT_EQ(Bindings({
                 Binding{FieldPath{"x"}, "$%/ \n"},
+            }),
+            bindings);
+}
+
+TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsEncodingEscape) {
+  MethodInfo* a = AddPathWithBodyFieldPathEscape("GET", "/a", "", "", true);
+  Build();
+
+  EXPECT_NE(nullptr, a);
+
+  Bindings bindings;
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=Hello%20world", &bindings), a);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "Hello%20world"},
+            }),
+            bindings);
+
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=%24%25%2F%20%0A", &bindings), a);
+  EXPECT_EQ(Bindings({
+                Binding{FieldPath{"x"}, "%24%25%2F%20%0A"},
             }),
             bindings);
 }

--- a/src/api_manager/path_matcher_test.cc
+++ b/src/api_manager/path_matcher_test.cc
@@ -52,7 +52,7 @@ class MethodInfo {
  public:
   MOCK_CONST_METHOD0(system_query_parameter_names,
                      const std::set<std::string>&());
-  MOCK_CONST_METHOD0(escape_binding, bool());
+  MOCK_CONST_METHOD0(keep_binding_escaped, bool());
 };
 
 bool operator==(const Binding& b1, const Binding& b2) {
@@ -76,11 +76,12 @@ class PathMatcherTest : public ::testing::Test {
                                              std::string http_template,
                                              std::string body_field_path,
                                              std::string expected_error,
-                                             bool escape_binding) {
+                                             bool keep_binding_escaped) {
     auto method = new NiceMock<MethodInfo>();
     ON_CALL(*method, system_query_parameter_names())
         .WillByDefault(ReturnRef(empty_set_));
-    ON_CALL(*method, escape_binding()).WillByDefault(Return(escape_binding));
+    ON_CALL(*method, keep_binding_escaped())
+        .WillByDefault(Return(keep_binding_escaped));
     auto status =
         builder_.Register(http_method, http_template, body_field_path, method);
     if (!status.ok()) {
@@ -100,7 +101,7 @@ class PathMatcherTest : public ::testing::Test {
     auto method = new NiceMock<MethodInfo>();
     ON_CALL(*method, system_query_parameter_names())
         .WillByDefault(ReturnRef(*system_params));
-    ON_CALL(*method, escape_binding()).WillByDefault(Return(false));
+    ON_CALL(*method, keep_binding_escaped()).WillByDefault(Return(false));
     if (!builder_.Register(http_method, http_template, std::string(), method)
              .ok()) {
       delete method;

--- a/src/grpc/transcoding/transcoder_test.cc
+++ b/src/grpc/transcoding/transcoder_test.cc
@@ -108,6 +108,7 @@ class TestMethodInfo : public MethodInfo {
     static std::set<std::string> dummy;
     return dummy;
   };
+  bool escape_binding() const { return false; }
 
   const std::vector<std::pair<std::string, int>> &metric_cost_vector() const {
     return metric_cost_vector_;

--- a/src/grpc/transcoding/transcoder_test.cc
+++ b/src/grpc/transcoding/transcoder_test.cc
@@ -108,7 +108,7 @@ class TestMethodInfo : public MethodInfo {
     static std::set<std::string> dummy;
     return dummy;
   };
-  bool escape_binding() const { return false; }
+  bool keep_binding_escaped() const { return false; }
 
   const std::vector<std::pair<std::string, int>> &metric_cost_vector() const {
     return metric_cost_vector_;

--- a/src/nginx/module.cc
+++ b/src/nginx/module.cc
@@ -133,12 +133,10 @@ void ngx_esp_override_backend_path(ngx_http_request_t *r,
                               " " + ngx_str_to_std(r->http_protocol),
                           &r->request_line);
 
-    std::size_t found = backend_path.find_first_of('?');
-    if (found != std::string::npos) {
-      std::string uri;
-      url_decode(backend_path.substr(0, backend_path.find_first_of('?')), uri);
-      ngx_str_copy_from_std(r->pool, uri, &r->uri);
-    }
+    std::string decoded_uri;
+    std::string uri = backend_path.substr(0, backend_path.find_first_of('?'));
+    url_decode(uri, decoded_uri);
+    ngx_str_copy_from_std(r->pool, decoded_uri, &r->uri);
   }
 }
 

--- a/src/nginx/t/backend_routing_append_path.t
+++ b/src/nginx/t/backend_routing_append_path.t
@@ -103,7 +103,7 @@ $t->run();
 my $response1 = ApiManager::http_get($NginxPort,'/shelves?key=this-is-an-api-key');
 
 # Backend address with a path prefix.
-my $response123 = ApiManager::http_get($NginxPort,'/shelves/123?key=this-is-an-api-key');
+my $response123 = ApiManager::http_get($NginxPort,'/shelves/123?key=this-is-an-api-key&site=space%20plus%2B2U%3D');
 
 # Backend address with an unexpected "/" sufix, should still work.
 my $response2 = ApiManager::http_get($NginxPort,'/shelves/123/books/1234?key=this-is-an-api-key&timezone=EST');
@@ -153,7 +153,7 @@ Connection: close
 /shelves
 EOF
 
-  $server->on('GET', '/foo/shelves/123?key=this-is-an-api-key', <<'EOF');
+  $server->on('GET', '/foo/shelves/123?key=this-is-an-api-key&site=space%20plus%2B2U%3D', <<'EOF');
 HTTP/1.1 200 OK
 Connection: close
 

--- a/src/nginx/t/backend_routing_constant_address.t
+++ b/src/nginx/t/backend_routing_constant_address.t
@@ -139,7 +139,7 @@ $t->run();
 
 # PathTranslation is set as CONSTANT_ADDRESS. Authorization header is added
 # from freshing token, with audience override.
-my $response1 = ApiManager::http_get($NginxPort,'/shelves?key=this-is-an-api-key');
+my $response1 = ApiManager::http_get($NginxPort,'/shelves?key=this-is-an-api-key&site=space%20plus%2B2U%3D');
 
 # PathTranslation is set as CONSTANT_ADDRESS, with binding variables.
 # no Authorization header is added.
@@ -223,7 +223,7 @@ sub bookstore {
     or die "Can't create test server socket: $!\n";
   local $SIG{PIPE} = 'IGNORE';
 
-  $server->on('GET', '/listShelves', <<'EOF');
+  $server->on('GET', '/listShelves?site=space%20plus%2B2U%3D', <<'EOF');
 HTTP/1.1 200 OK
 Connection: close
 


### PR DESCRIPTION
When x-google-backend is using CONSTANT_ADDRESS as path translation, if the query parameter has escaped characters, they will be unescaped when passing the request to the backend.

Issue: https://github.com/cloudendpoints/esp/issues/681

Also fixed a bug in module.cc where if uri doen't have query parameter, r.uri field is not changed.