### PR TITLE
Add 2 more values to template vars to make multiple backend support better

### DIFF
--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -164,6 +164,7 @@ def write_nginx_conf(ingress, nginx_conf, args):
             experimental_proxy_backend_host_header=args.experimental_proxy_backend_host_header,
             enable_strict_transport_security=args.enable_strict_transport_security,
             google_cloud_platform=(args.non_gcp==False),
+            server_config_dir=args.server_config_dir,
             services=args.services)
 
     # Save nginx conf

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -163,7 +163,8 @@ def write_nginx_conf(ingress, nginx_conf, args):
             server_config_path=args.server_config_path,
             experimental_proxy_backend_host_header=args.experimental_proxy_backend_host_header,
             enable_strict_transport_security=args.enable_strict_transport_security,
-            google_cloud_platform=(args.non_gcp==False))
+            google_cloud_platform=(args.non_gcp==False),
+            services=args.services)
 
     # Save nginx conf
     try:


### PR DESCRIPTION
This allows us to use a template that can leverage `${services}` rather than having to hardcode the list of multiple services when using `--experimental_enable_multiple_api_configs`.