### PR TITLE
Get ready for building service config into serverless docker image

### DIFF
--- a/docker/serverless/Dockerfile.with_config
+++ b/docker/serverless/Dockerfile.with_config
@@ -1,0 +1,7 @@
+# Serverless ESP docker image with build-in service config
+FROM ${PARENT_IMAGE}
+
+ENV ENDPOINTS_SERVICE_PATH /etc/nginx/service.json
+ADD service.json ${ENDPOINTS_SERVICE_PATH}
+
+ENTRYPOINT ["/env-start-esp.py"]

--- a/docker/serverless/Dockerfile.with_config
+++ b/docker/serverless/Dockerfile.with_config
@@ -2,6 +2,6 @@
 FROM _SERVERLESS_IMAGE
 
 ENV ENDPOINTS_SERVICE_PATH /etc/nginx/service.json
-ADD service.json ${ENDPOINTS_SERVICE_PATH}
+COPY service.json ${ENDPOINTS_SERVICE_PATH}
 
 ENTRYPOINT ["/env-start-esp.py"]

--- a/docker/serverless/Dockerfile.with_config
+++ b/docker/serverless/Dockerfile.with_config
@@ -1,5 +1,5 @@
 # Serverless ESP docker image with build-in service config
-FROM ${PARENT_IMAGE}
+FROM _SERVERLESS_IMAGE
 
 ENV ENDPOINTS_SERVICE_PATH /etc/nginx/service.json
 ADD service.json ${ENDPOINTS_SERVICE_PATH}

--- a/docker/serverless/env-start-esp.py
+++ b/docker/serverless/env-start-esp.py
@@ -74,15 +74,23 @@ def main():
         serve_error_msg(error.message)
     ARGS.append("--service={}".format(os.environ["ENDPOINTS_SERVICE_NAME"]))
 
-    if "ENDPOINTS_SERVICE_VERSION" in os.environ:
+    if "ENDPOINTS_SERVICE_PATH" in os.environ:
         ARGS.extend(
             [
                 "--rollout_strategy=fixed",
-                "--version={}".format(os.environ["ENDPOINTS_SERVICE_VERSION"]),
+                "--service_json_path={}".format(os.environ["ENDPOINTS_SERVICE_PATH"]),
             ]
         )
     else:
-        ARGS.append("--rollout_strategy=managed")
+        if "ENDPOINTS_SERVICE_VERSION" in os.environ:
+            ARGS.extend(
+                [
+                    "--rollout_strategy=fixed",
+                    "--version={}".format(os.environ["ENDPOINTS_SERVICE_VERSION"]),
+                ]
+             )
+        else:
+            ARGS.append("--rollout_strategy=managed")
 
     if "CORS_PRESET" in os.environ:
         ARGS.append("--cors_preset={}".format(os.environ["CORS_PRESET"]))

--- a/docker/serverless/env-start-esp.py
+++ b/docker/serverless/env-start-esp.py
@@ -68,12 +68,6 @@ def main():
     assert_env_var("PORT")
     ARGS.append("--http_port={}".format(os.environ["PORT"]))
 
-    try:
-        assert_env_var("ENDPOINTS_SERVICE_NAME")
-    except KeyError as error:
-        serve_error_msg(error.message)
-    ARGS.append("--service={}".format(os.environ["ENDPOINTS_SERVICE_NAME"]))
-
     if "ENDPOINTS_SERVICE_PATH" in os.environ:
         ARGS.extend(
             [
@@ -82,6 +76,12 @@ def main():
             ]
         )
     else:
+        try:
+            assert_env_var("ENDPOINTS_SERVICE_NAME")
+        except KeyError as error:
+            serve_error_msg(error.message)
+        ARGS.append("--service={}".format(os.environ["ENDPOINTS_SERVICE_NAME"]))
+
         if "ENDPOINTS_SERVICE_VERSION" in os.environ:
             ARGS.extend(
                 [

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -968,8 +968,6 @@ def enforce_conflict_args(args):
             return "Flag --enable_backend_routing cannot be used together with --service_control_url_override."
         if args.metadata != METADATA_ADDRESS:
             return "Flag --enable_backend_routing cannot be used together with --metadata."
-        if args.service_json_path:
-            return "Flag --enable_backend_routing cannot be used together with --service_json_path."
         if args.worker_processes != DEFAULT_WORKER_PROCESSES:
             return "Flag --enable_backend_routing cannot be used together with --worker_processes."
         if args.rewrite:


### PR DESCRIPTION
This PR just to get ESP code ready for building service config into serverless image
Separate pr will check in a script for users to build the image

1) Provide a docker file to build service config into docker
2) use flag --service_json_path to specify the service config, and enable it