### PR TITLE
Fix e2e echo test failure

### DIFF
--- a/test/echo/app_esp.yaml
+++ b/test/echo/app_esp.yaml
@@ -44,6 +44,12 @@ beta_settings:
   allow_ssh: true
   gae_nginx_proxy_image_name: ${IMAGE_NAME}
 
+liveness_check:
+  path: "/version"
+
+readiness_check:
+  path: "/version"
+
 skip_files:
 - ^(.*/)?#.*#$
 - ^(.*/)?.*~$


### PR DESCRIPTION
There is another FLEX test: echo need to set readiness_check.  We are using "/version" for both.