### PR TITLE
fixed option description for disable sampling

### DIFF
--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -835,7 +835,7 @@ config file.'''.format(
         help='''
         Disable cloud trace auto sampling. By default, 1 request out of every
         1000 or 1 request out of every 10 seconds is enabled with cloud trace.
-        Set this flag to false to disable such auto sampling. Cloud trace can
+        Set this flag to disable such auto sampling. Cloud trace can
         still be enabled from request HTTP headers with trace context regardless
         this flag value.
         ''')


### PR DESCRIPTION
It seems like "Set this flag to false to disable" should be "Set this flag to disable". It doesn't require additional args, such as true/false, but looks like it need one.