### PR TITLE
Only apply network_fail_open policy to 5xx Http status code

### DIFF
--- a/src/api_manager/service_control/aggregated.cc
+++ b/src/api_manager/service_control/aggregated.cc
@@ -93,6 +93,16 @@ const char servicecontrol_service[] =
 const char quotacontrol_service[] =
     "/google.api.servicecontrol.v1.QuotaController";
 
+// Define network failure error codes:
+// All 500 Http status codes are maked as network failure.
+// Http status code is converted to Status::code as:
+// https://github.com/cloudendpoints/esp/blob/master/src/api_manager/utils/status.cc#L364
+// which is called by Status.ToProto() at Aggregated::Call() on_done function.
+bool IsErrorCodeNetworkFailure(int code) {
+  return code == Code::UNAVAILABLE || code == Code::INTERNAL ||
+         code == Code::UNIMPLEMENTED || code == Code::DEADLINE_EXCEEDED;
+}
+
 // Generates CheckAggregationOptions.
 CheckAggregationOptions GetCheckAggregationOptions(
     const ServerConfig* server_config) {
@@ -371,9 +381,13 @@ void Aggregated::Check(
           *response, service_control_proto_.service_name(), &response_info);
       on_done(status, response_info);
     } else {
-      // Only Code::UNAVAILABLE error is network failure.
       // If network_fail_open is true, it is OK to proceed
-      if (network_fail_open_ && status.error_code() == Code::UNAVAILABLE) {
+      if (network_fail_open_ &&
+          IsErrorCodeNetworkFailure(status.error_code())) {
+        env_->LogError(
+            std::string("With network fail open policy, the request is allowed "
+                        "even the service control check failed with: " +
+                        status.ToString()));
         on_done(Status::OK, response_info);
       } else {
         on_done(Status(status.error_code(), status.error_message(),

--- a/src/api_manager/service_control/aggregated.cc
+++ b/src/api_manager/service_control/aggregated.cc
@@ -94,7 +94,7 @@ const char quotacontrol_service[] =
     "/google.api.servicecontrol.v1.QuotaController";
 
 // Define network failure error codes:
-// All 500 Http status codes are maked as network failure.
+// All 500 Http status codes are marked as network failure.
 // Http status code is converted to Status::code as:
 // https://github.com/cloudendpoints/esp/blob/master/src/api_manager/utils/status.cc#L364
 // which is called by Status.ToProto() at Aggregated::Call() on_done function.

--- a/src/api_manager/service_control/aggregated.cc
+++ b/src/api_manager/service_control/aggregated.cc
@@ -94,7 +94,7 @@ const char quotacontrol_service[] =
     "/google.api.servicecontrol.v1.QuotaController";
 
 // Define network failure error codes:
-// All 500 Http status codes are marked as network failure.
+// All 5xx Http status codes are marked as network failure.
 // Http status code is converted to Status::code as:
 // https://github.com/cloudendpoints/esp/blob/master/src/api_manager/utils/status.cc#L364
 // which is called by Status.ToProto() at Aggregated::Call() on_done function.

--- a/src/nginx/t/BUILD
+++ b/src/nginx/t/BUILD
@@ -208,6 +208,7 @@ nginx_suite(
         "check_referer.t",
         "check_report_body.t",
         "check_report_metrics.t",
+        "check_return_403.t",
         "check_with_token.t",
         "config_extra_field.t",
         "config_missing.t",

--- a/src/nginx/t/check_network_failures.t
+++ b/src/nginx/t/check_network_failures.t
@@ -41,7 +41,7 @@ my $NginxPort = ApiManager::pick_port();
 my $BackendPort = ApiManager::pick_port();
 my $ServiceControlPort = ApiManager::pick_port();
 
-my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(13);
+my $t = Test::Nginx->new()->has(qw/http proxy/)->plan(18);
 
 ApiManager::write_file_expand($t, 'sc_timeout.pb.txt', <<"EOF");
 service_control_config {
@@ -144,7 +144,7 @@ is($bookstore_requests2, '', 'Request did not reach the backend.');
 ################################################################################
 
 $t->run_daemon(\&bookstore, $t, $BackendPort, 'bookstore.log');
-$t->run_daemon(\&servicecontrol, $t, $ServiceControlPort, 'servicecontrol.log');
+$t->run_daemon(\&servicecontrol_sleep, $t, $ServiceControlPort, 'servicecontrol.log');
 is($t->waitforsocket("127.0.0.1:${BackendPort}"), 1, 'Bookstore socket ready.');
 is($t->waitforsocket("127.0.0.1:${ServiceControlPort}"), 1, 'Service control socket ready.');
 $t->run();
@@ -161,8 +161,32 @@ my $bookstore_requests3 = $t->read_file('bookstore.log');
 is($bookstore_requests3, '', 'Request did not reach the backend.');
 
 ################################################################################
+#
+#  service_control check return 502
+#  starts Nginx, service_control and backend.
+#
+################################################################################
 
-sub servicecontrol {
+$t->run_daemon(\&bookstore, $t, $BackendPort, 'bookstore.log');
+$t->run_daemon(\&servicecontrol_502, $t, $ServiceControlPort, 'servicecontrol.log');
+is($t->waitforsocket("127.0.0.1:${BackendPort}"), 1, 'Bookstore socket ready.');
+is($t->waitforsocket("127.0.0.1:${ServiceControlPort}"), 1, 'Service control socket ready.');
+$t->run();
+
+my $response4 = ApiManager::http_get($NginxPort,'/shelves?key=this-is-an-api-key');
+
+$t->stop();
+$t->stop_daemons();
+
+like($response4, qr/HTTP\/1\.1 500 Internal Server Error/, 'Returned HTTP 500.');
+like($response4, qr/Server error messages/i, 'Client received failed check response body');
+
+my $bookstore_requests3 = $t->read_file('bookstore.log');
+is($bookstore_requests3, '', 'Request did not reach the backend.');
+
+################################################################################
+
+sub servicecontrol_sleep {
   my ($t, $port, $file) = @_;
   my $server = HttpServer->new($port, $t->testdir() . '/' . $file)
     or die "Can't create test server socket: $!\n";
@@ -178,6 +202,26 @@ sub servicecontrol {
 HTTP/1.1 200 OK
 Connection: close
 
+EOF
+  });
+
+  $server->run();
+}
+
+sub servicecontrol_502 {
+  my ($t, $port, $file) = @_;
+  my $server = HttpServer->new($port, $t->testdir() . '/' . $file)
+    or die "Can't create test server socket: $!\n";
+  local $SIG{PIPE} = 'IGNORE';
+
+  $server->on_sub('POST', '/v1/services/endpoints-test.cloudendpointsapis.com:check', sub {
+    my ($headers, $body, $client) = @_;
+
+    print $client <<'EOF';
+HTTP/1.1 502 OK
+Connection: close
+
+Server error messages
 EOF
   });
 

--- a/src/nginx/t/failed_check.t
+++ b/src/nginx/t/failed_check.t
@@ -99,7 +99,7 @@ like($response1, qr/content-type: application\/json/i,
 like($response1, qr/API endpoints-test.cloudendpointsapis.com is not enabled for the consumer project/i,
   "Error body contains 'activation error'.");
 
-like($response2, qr/HTTP\/1\.1 503 Service Temporarily Unavailable/, 'Response2 returned HTTP 503.');
+like($response2, qr/HTTP\/1\.1 403 Forbidden/, 'Response2 returned HTTP 403.');
 like($response2, qr/content-type: application\/json/i,
      'Unauthorized returned application/json body.');
 like($response2, qr/Service control request failed/i, "Error body contains 'service control failed'.");


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

If ServiceControl  error response has body, it may contain important debug info, also pass that info to the client.
