### PR TITLE
(DO NOT SUBMIT) not to pin google-auth to 1.7.0

### DIFF
--- a/start_esp/BUILD
+++ b/start_esp/BUILD
@@ -53,7 +53,7 @@ pex_binary(
     reqs = [
         "certifi",
         "mako>=1.0.4",
-        "google-auth==1.7.0",
+        "google-auth",
         "google-auth-httplib2",
         "google-api-python-client",
         "requests",


### PR DESCRIPTION
It caused Jenkins presubmit test failed with

Could not satisfy all requirements for google-auth==1.7.0:
    google-auth==1.7.0, google-auth(from: google-auth-httplib2), google-auth>=1.4.1(from: google-api-python-client), google-auth<2.0dev,>=1.14.0(from: google-api-python-client->google-api-core<2dev,>=1.13.0)
