### PR TITLE
Rollback google auth

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,7 @@ SUPPORTED_STAGES = [
 ]
 
 // Supported VM Images
-SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-9:0.12'
+SLAVE_IMAGE = 'gcr.io/endpoints-jenkins/debian-9:0.13'
 
 // Release Qualification end to end tests.
 // If RAPTURE_REPO build parameter is set only those test will run.
@@ -221,7 +221,6 @@ def presubmit() {
       'release': {
         BuildNode {
           presubmitTests('release')
-          presubmitTests('docker-tests', false)
         }
       },
       'tsan': {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -221,6 +221,7 @@ def presubmit() {
       'release': {
         BuildNode {
           presubmitTests('release')
+          presubmitTests('docker-tests', false)
         }
       },
       'tsan': {

--- a/jenkins/slaves/Makefile
+++ b/jenkins/slaves/Makefile
@@ -1,5 +1,5 @@
 PROJECT = endpoints-jenkins
-VERSION = 0.12
+VERSION = 0.13
 TOOLS_BUCKET = endpoints-tools
 
 # Note: The build directory is the root of the istio/test-infra repository, not ./

--- a/script/linux-install-software
+++ b/script/linux-install-software
@@ -101,7 +101,7 @@ ${SUDO} apt-get clean
 retry install_packages || error_exit 'Cannot install required packages.'
 retry ${SUDO} pip install --upgrade python-gflags || error_exit 'Cannot install gflags.'
 retry ${SUDO} pip install --upgrade certifi || error_exit 'Cannot install certifi.'
-retry ${SUDO} pip install --upgrade requests google-auth google-auth-httplib2 google-api-python-client || error_exit 'Cannot install google-auth.'
+retry ${SUDO} pip install --upgrade oauth2client || error_exit 'Cannot install oauth2client.'
 retry ${SUDO} pip install --upgrade urllib3 || error_exit 'Cannot install urllib3.'
 retry ${SUDO} pip install --upgrade prettytable Mako pyaml dateutils || error_exit 'Cannot install prettytable Mako pyaml dateutils.'
 

--- a/start_esp/BUILD
+++ b/start_esp/BUILD
@@ -53,10 +53,7 @@ pex_binary(
     reqs = [
         "certifi",
         "mako>=1.0.4",
-        "google-auth==1.7.0",
-        "google-auth-httplib2",
-        "google-api-python-client",
-        "requests",
+        "oauth2client>=3.0.0",
         "pyasn1>=0.1.9",
         "pyasn1-modules>=0.0.8",
         "urllib3>=1.16",

--- a/start_esp/fetch_service_config.py
+++ b/start_esp/fetch_service_config.py
@@ -147,7 +147,7 @@ def make_access_token(secret_token_json):
     credentials = ServiceAccountCredentials.from_json_keyfile_name(
         secret_token_json,
         scopes=[_GOOGLE_API_SCOPE])
-    logging.info("Service account email: " + cred.service_account_email)
+    logging.info("Service account email: " + credentials.service_account_email)
     token = credentials.get_access_token().access_token
     return token
 

--- a/start_esp/fetch_service_config.py
+++ b/start_esp/fetch_service_config.py
@@ -29,8 +29,7 @@ import certifi
 import json
 import logging
 import urllib3
-import google.oauth2.service_account
-from google.auth.transport.requests import Request
+from oauth2client.service_account import ServiceAccountCredentials
 
 # Service management service
 SERVICE_MGMT_ROLLOUTS_URL_TEMPLATE = (
@@ -145,17 +144,12 @@ def fetch_metadata_attributes(metadata):
 def make_access_token(secret_token_json):
     """Construct an access token from service account token."""
     logging.info("Constructing an access token with scope " + _GOOGLE_API_SCOPE)
-    cred = google.oauth2.service_account.Credentials.from_service_account_file(
+    credentials = ServiceAccountCredentials.from_json_keyfile_name(
         secret_token_json,
         scopes=[_GOOGLE_API_SCOPE])
     logging.info("Service account email: " + cred.service_account_email)
-    body = {
-        'assertion': cred._make_authorization_grant_assertion(),
-        'grant_type': google.oauth2._client._JWT_GRANT_TYPE,
-    }
-    token_response = google.oauth2._client._token_endpoint_request(
-        google.auth.transport.requests.Request(), cred._token_uri, body)
-    return  token_response["access_token"] if "access_token" in token_response else ""
+    token = credentials.get_access_token().access_token
+    return token
 
 def fetch_access_token(metadata):
     """Fetch access token from metadata URL."""

--- a/test/bookstore/swagger_template.json
+++ b/test/bookstore/swagger_template.json
@@ -5,7 +5,7 @@
     "title": "Bookstore",
     "version": "1.0.0"
   },
-  "host": "${ENDPOINT_SERVICE}",
+  "host": "gke-tight-http-bookstore-secure.endpoints-jenkins.appspot.com",
   "basePath": "/",
   "consumes": [
     "application/json"

--- a/test/bookstore/swagger_template.json
+++ b/test/bookstore/swagger_template.json
@@ -5,7 +5,7 @@
     "title": "Bookstore",
     "version": "1.0.0"
   },
-  "host": "gke-tight-http-bookstore-secure.endpoints-jenkins.appspot.com",
+  "host": "${ENDPOINT_SERVICE}",
   "basePath": "/",
   "consumes": [
     "application/json"


### PR DESCRIPTION

As google-auth doesn't support python2.7 any more. 
But ESP has to stay with python2.7 since its bazel stay at 0.21.