### PR TITLE
Increase timeout of fetching access token from metadata server to 5s

### DIFF
--- a/src/api_manager/fetch_metadata.cc
+++ b/src/api_manager/fetch_metadata.cc
@@ -42,10 +42,11 @@ const char kMetadataInstanceIdentityToken[] =
 const int kInstanceIdentityTokenExpiration = 3500;
 // Time window (in seconds) of failure status after a failed fetch.
 const int kFailureStatusWindow = 5;
-// Initial metadata fetch timeout (1s)
-const int kMetadataFetchTimeout = 1000;
+// GKE metadata server may take >2s to fetch access token.
+// Initial metadata fetch timeout (5s)
+const int kMetadataFetchTimeout = 5000;
 // Maximum number of retries to fetch token from metadata
-const int kMetadataTokenFetchRetries = 5;
+const int kMetadataTokenFetchRetries = 3;
 // External status message for failure to fetch service account token
 const char kFailedTokenFetch[] = "Failed to fetch service account token";
 // External status message for token fetch in progress

--- a/src/nginx/t/metadata_timeout.t
+++ b/src/nginx/t/metadata_timeout.t
@@ -208,7 +208,7 @@ sub metadata {
     $request_count++;
     if ($request_count == 1) {
         # Trigger a timeout for the first request.
-        sleep 2;
+        sleep 7;
     }
 
     print $client <<'EOF';


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

b/148454048: GKE metadata server needs > 2s to fetch access token. 
Increase ESP access token fetching timeout to 5s (from 1s).

