### PR TITLE
fix e2e tests: remove espcli in gke-e2e tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -283,11 +283,6 @@ def e2eTest() {
           e2eGKE('tight', 'http', 'managed')
         }
       }],
-      ['gke-loose-http', {
-        DefaultNode {
-          e2eGKE('loose', 'http', 'fixed')
-        }
-      }],
       ['gke-custom-http', {
         DefaultNode {
           e2eGKE('custom', 'http', 'fixed')
@@ -296,11 +291,6 @@ def e2eTest() {
       ['gke-tight-https', {
         DefaultNode {
           e2eGKE('tight', 'https', 'fixed')
-        }
-      }],
-      ['gke-loose-https', {
-        DefaultNode {
-          e2eGKE('loose', 'https', 'fixed')
         }
       }],
       ['flex', {

--- a/script/e2e-kube.sh
+++ b/script/e2e-kube.sh
@@ -93,7 +93,12 @@ run kubectl create secret generic esp-ssl \
 
 run kubectl create --validate=false -f ${YAML_FILE}          --namespace "${NAMESPACE}"
 
-SERVICE_IP=$(get_gke_service_ip "${NAMESPACE}" "bookstore")
+SERVICE_IP=$(get_gke_service_ip "${NAMESPACE}" "bookstore") || {
+    run kubectl -n "${NAMESPACE}" get service "bookstore "
+    run kubectl logs $(kubectl get pods -n ${NAMESPACE} --no-headers|awk '{print $1}') -c esp -n ${NAMESPACE}
+    error_exit "Failed to get external_ip"
+}
+
 case "${TEST_TYPE}" in
   'http'  ) HOST="http://${SERVICE_IP}";;
   'http2' ) HOST="${SERVICE_IP}:80";;

--- a/script/e2e-kube.sh
+++ b/script/e2e-kube.sh
@@ -33,8 +33,6 @@ YAML_FILE=${ESP_ROOT}/test/bookstore/backend.yaml
 
 . ${ESP_ROOT}/script/jenkins-utilities || { echo "Cannot load Jenkins Bash utilities" ; exit 1 ; }
 
-set -x
-
 e2e_options "${@}"
 
 TEST_ID="gke-${COUPLING_OPTION}-${TEST_TYPE}-${BACKEND}"

--- a/script/e2e-kube.sh
+++ b/script/e2e-kube.sh
@@ -33,6 +33,8 @@ YAML_FILE=${ESP_ROOT}/test/bookstore/backend.yaml
 
 . ${ESP_ROOT}/script/jenkins-utilities || { echo "Cannot load Jenkins Bash utilities" ; exit 1 ; }
 
+set -x
+
 e2e_options "${@}"
 
 TEST_ID="gke-${COUPLING_OPTION}-${TEST_TYPE}-${BACKEND}"
@@ -131,7 +133,7 @@ if [[ ("${ESP_ROLLOUT_STRATEGY}" == "managed") && ("${BACKEND}" == "bookstore") 
     || error_exit 'Rollouts update was failed'
 fi
 
-run ${CLI} logs bookstore --namespace ${NAMESPACE} --project ${PROJECT_ID} --active=false \
+run kubectl logs $(kubectl get pods -n ${NAMESPACE} --no-headers|awk '{print $1}') -c esp -n ${NAMESPACE} \
   | tee ${LOG_DIR}/error.log
 
 if [[ -n $REMOTE_LOG_DIR ]]; then

--- a/script/e2e-kube.sh
+++ b/script/e2e-kube.sh
@@ -30,6 +30,7 @@ SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ESP_ROOT="$(cd "${SCRIPT_PATH}/../" && pwd)"
 YAML_TEMP_FILE=${ESP_ROOT}/test/bookstore/backend.yaml_temp
 YAML_FILE=${ESP_ROOT}/test/bookstore/backend.yaml
+ESP_GKE_SERVICE=bookstore
 
 . ${ESP_ROOT}/script/jenkins-utilities || { echo "Cannot load Jenkins Bash utilities" ; exit 1 ; }
 
@@ -93,8 +94,8 @@ run kubectl create secret generic esp-ssl \
 
 run kubectl create --validate=false -f ${YAML_FILE}          --namespace "${NAMESPACE}"
 
-SERVICE_IP=$(get_gke_service_ip "${NAMESPACE}" "bookstore") || {
-    run kubectl -n "${NAMESPACE}" get service "bookstore "
+SERVICE_IP=$(get_gke_service_ip "${NAMESPACE}" "${ESP_GKE_SERVICE}") || {
+    run kubectl -n "${NAMESPACE}" get service "${ESP_GKE_SERVICE}"
     run kubectl logs $(kubectl get pods -n ${NAMESPACE} --no-headers|awk '{print $1}') -c esp -n ${NAMESPACE}
     error_exit "Failed to get external_ip"
 }

--- a/script/e2e-kube.sh
+++ b/script/e2e-kube.sh
@@ -28,27 +28,10 @@
 #
 SCRIPT_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ESP_ROOT="$(cd "${SCRIPT_PATH}/../" && pwd)"
-CLI="$ESP_ROOT/espcli"
-YAML_FILE=${ESP_ROOT}/test/bookstore/bookstore.yaml
-ESP_APP="esp"
+YAML_TEMP_FILE=${ESP_ROOT}/test/bookstore/backend.yaml_temp
+YAML_FILE=${ESP_ROOT}/test/bookstore/backend.yaml
 
 . ${ESP_ROOT}/script/jenkins-utilities || { echo "Cannot load Jenkins Bash utilities" ; exit 1 ; }
-
-# Fetch CLI tool if it is not available
-if [[ ! -f $CLI ]]; then
-  OSNAME=`uname | tr "[:upper:]" "[:lower:]"`
-  URL="https://storage.googleapis.com/endpoints-release/v1.0.4/bin/${OSNAME}/amd64/espcli"
-  curl -o ${CLI} ${URL}
-  chmod +x ${CLI}
-fi
-
-function cleanup {
-  if [[ "${SKIP_CLEANUP}" == 'false' ]]; then
-    run kubectl delete namespace "${NAMESPACE}"
-    # Uncomment this line when the limit on #services is lifted or increased to > 20
-    # run gcloud endpoints services delete ${ESP_SERVICE} --quiet
-  fi
-}
 
 e2e_options "${@}"
 
@@ -61,63 +44,62 @@ fi
 ESP_SERVICE="${TEST_ID}.${PROJECT_ID}.appspot.com"
 
 NAMESPACE="${UNIQUE_ID}"
-ARGS="\
-  -N 8090 \
-  --access_log off \
-  --service ${ESP_SERVICE} \
-  --project ${PROJECT_ID} \
-  --image ${ESP_IMAGE} \
-  --sslCert ${ESP_ROOT}/tools/src/testdata/nginx.crt \
-  --sslKey ${ESP_ROOT}/tools/src/testdata/nginx.key \
-"
-run sed_i "s|image:.*|image: ${BOOKSTORE_IMAGE}|g" ${YAML_FILE}
-run cat ${YAML_FILE}
+ARGS="\"--status_port=8090\", \"--access_log=off\", \"--service=${ESP_SERVICE}\""
 
 case "${BACKEND}" in
   'bookstore' )
     SERVICE_IDL="${ESP_ROOT}/test/bookstore/swagger_template.json"
-    CREATE_SERVICE_ARGS="${SERVICE_IDL}";;
+    CREATE_SERVICE_ARGS="${SERVICE_IDL}"
+    ARGS="$ARGS, \"--backend=127.0.0.1:8081\"";;
   'echo'      )
     SERVICE_IDL="${ESP_ROOT}/test/grpc/grpc-test.yaml"
     CREATE_SERVICE_ARGS="${SERVICE_IDL} ${ESP_ROOT}/bazel-genfiles/test/grpc/grpc-test.descriptor"
-    ARGS="$ARGS -g";;
+    ARGS="$ARGS, \"--backend=grpc://127.0.0.1:8081\"";;
   'interop'   )
     SERVICE_IDL="${ESP_ROOT}/test/grpc/grpc-interop.yaml"
     CREATE_SERVICE_ARGS="${SERVICE_IDL} ${ESP_ROOT}/bazel-genfiles/test/grpc/grpc-interop.descriptor"
-    ARGS="$ARGS -g";;
+    ARGS="$ARGS, \"--backend=grpc://127.0.0.1:8081\"";;
   *           ) e2e_usage "Invalid backend option";;
 esac
 
 run sed -i "s|\${ENDPOINT_SERVICE}|${ESP_SERVICE}|g" ${SERVICE_IDL}
 create_service "${ESP_SERVICE}" "${CREATE_SERVICE_ARGS}"
-ARGS="$ARGS --version ${ESP_SERVICE_VERSION}"
+ARGS="$ARGS, \"--version=${ESP_SERVICE_VERSION}\", \"--rollout_strategy=${ESP_ROLLOUT_STRATEGY}\""
 
-case "${COUPLING_OPTION}" in
-  'loose' ) ARGS="$ARGS -d loose";;
-  'tight' ) ARGS="$ARGS -d tight";;
-  'custom') ARGS="$ARGS -d tight -n ${ESP_ROOT}/test/bookstore/gke/nginx.conf";;
-  *       ) e2e_usage "Invalid test option";;
-esac
-
-HOST="${ESP_APP}.${NAMESPACE}.svc.cluster.local"
 case "${TEST_TYPE}" in
-  'http'  ) ARGS="$ARGS -p 80";         HOST="http://${HOST}";;
-  'http2' ) ARGS="$ARGS -P 80 -p 8080"; HOST="${HOST}:80";;
-  'https' ) ARGS="$ARGS -S 443";        HOST="https://${HOST}";;
+  'http'  ) ARGS="$ARGS, \"--http_port=80\"";;
+  'http2' ) ARGS="$ARGS, \"--http2_port=80\", \"--http_port=8080\"";;
+  'https' ) ARGS="$ARGS, \"--ssl_port=443\"";;
   *       ) e2e_usage "Invalid test type";;
 esac
 
-# set rollout strategy
-ARGS="$ARGS --rollout_strategy ${ESP_ROLLOUT_STRATEGY}"
+if [[ "${COUPLING_OPTION}" == 'custom' ]]; then
+    ARGS="$ARGS, \"-n=/etc/nginx/ssl/nginx.conf\""
+fi
 
-trap cleanup EXIT
+sed -e "s|BACKEND_IMAGE|${BOOKSTORE_IMAGE}|g" \
+    -e "s|ESP_IMAGE|${ESP_IMAGE}|g" \
+    -e "s|ESP_ARGS|${ARGS}|g" ${YAML_TEMP_FILE} | tee ${YAML_FILE}
+
+trap gke_namespace_cleanup EXIT
 
 # Testing protocol
 run kubectl create namespace "${NAMESPACE}" || error_exit "Namespace already exists"
-run kubectl create -f ${YAML_FILE}          --namespace "${NAMESPACE}"
-run $CLI deploy bookstore ${ESP_APP} $ARGS  --namespace "${NAMESPACE}"
-run kubectl get services -o yaml            --namespace "${NAMESPACE}"
-run kubectl get deployments -o yaml         --namespace "${NAMESPACE}"
+
+run kubectl create secret generic esp-ssl \
+    --from-file=${ESP_ROOT}/tools/src/testdata/nginx.crt \
+    --from-file=${ESP_ROOT}/tools/src/testdata/nginx.key \
+    --from-file=${ESP_ROOT}/test/bookstore/gke/nginx.conf  --namespace "${NAMESPACE}"
+
+run kubectl create --validate=false -f ${YAML_FILE}          --namespace "${NAMESPACE}"
+
+SERVICE_IP=$(get_gke_service_ip "${NAMESPACE}" "bookstore")
+case "${TEST_TYPE}" in
+  'http'  ) HOST="http://${SERVICE_IP}";;
+  'http2' ) HOST="${SERVICE_IP}:80";;
+  'https' ) HOST="https://${SERVICE_IP}";;
+  *       ) e2e_usage "Invalid test type";;
+esac
 
 LOG_DIR="$(mktemp -d /tmp/log.XXXX)"
 

--- a/script/jenkins-utilities
+++ b/script/jenkins-utilities
@@ -423,7 +423,7 @@ function gke_namespace_cleanup {
 function get_gke_service_ip () {
   local ns="${1}"
   local name="${2}"
-  local COUNT=10
+  local COUNT=30
   local SLEEP=15
   for i in $( seq 1 ${COUNT} ); do
     local host=$(kubectl -n "${ns}" get service "${name}" | awk '{print $4}' | grep -v EXTERNAL-IP)

--- a/script/jenkins-utilities
+++ b/script/jenkins-utilities
@@ -412,6 +412,34 @@ function get_host_ip() {
   return 0
 }
 
+function gke_namespace_cleanup {
+  if [[ "${SKIP_CLEANUP}" == 'false' ]]; then
+    run kubectl delete namespace "${NAMESPACE}"
+    # Uncomment this line when the limit on #services is lifted or increased to > 20
+    # run gcloud endpoints services delete ${ESP_SERVICE} --quiet
+  fi
+}
+
+function get_gke_service_ip () {
+  local ns="${1}"
+  local name="${2}"
+  local COUNT=10
+  local SLEEP=15
+  for i in $( seq 1 ${COUNT} ); do
+    local host=$(kubectl -n "${ns}" get service "${name}" | awk '{print $4}' | grep -v EXTERNAL-IP)
+      [ '<pending>' != $host ] && break
+      echo "Waiting for server external ip. Attempt  #$i/${COUNT}... will try again in ${SLEEP} seconds" >&2
+      sleep ${SLEEP}
+  done
+  if [[ '<pending>' == $host ]]; then
+    echo 'Failed to get the GKE cluster host.'
+    return 1
+  else
+    echo "$host"
+    return 0
+  fi
+}
+
 function e2e_usage() {
   local error_message="${1}"
   [[ -n "${error_message}" ]] && echo "${error_message}"

--- a/test/bookstore/backend.yaml_temp
+++ b/test/bookstore/backend.yaml_temp
@@ -1,0 +1,62 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: bookstore
+spec:
+  ports:
+  - port: 80
+    targetPort: 80
+    protocol: TCP
+    name: http
+  - port: 8080
+    targetPort: 8080
+    protocol: TCP
+    name: http2
+  - port: 8090
+    targetPort: 8090
+    protocol: TCP
+    name: status
+  - port: 443
+    targetPort: 443
+    protocol: TCP
+    name: ssl
+  selector:
+    app: bookstore
+  type: LoadBalancer
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bookstore
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: bookstore
+  template:
+    metadata:
+      labels:
+        app: bookstore
+    spec:
+      volumes:
+        - name: esp-ssl
+          secret:
+            secretName: esp-ssl
+      containers:
+      - name: esp
+        image: ESP_IMAGE
+        args: [ESP_ARGS]
+        ports:
+          - containerPort: 80
+          - containerPort: 8080
+          - containerPort: 8090
+          - containerPort: 443
+        volumeMounts:
+          - mountPath: /etc/nginx/ssl
+            name: esp-ssl
+            readOnly: true
+        imagePullPolicy: Always
+      - name: bookstore
+        image: BACKEND_IMAGE
+        ports:
+          - containerPort: 8081

--- a/test/grpc/grpc-interop.yaml
+++ b/test/grpc/grpc-interop.yaml
@@ -1,7 +1,7 @@
 type: google.api.Service
 config_version: 3
 title: GRPC Interop Test
-name: ${ENDPOINT_SERVICE}
+name: gke-tight-http2-interop.endpoints-jenkins.appspot.com
 apis:
 - name: grpc.testing.TestService
 usage:

--- a/test/grpc/grpc-interop.yaml
+++ b/test/grpc/grpc-interop.yaml
@@ -1,7 +1,7 @@
 type: google.api.Service
 config_version: 3
 title: GRPC Interop Test
-name: gke-tight-http2-interop.endpoints-jenkins.appspot.com
+name: ${ENDPOINT_SERVICE}
 apis:
 - name: grpc.testing.TestService
 usage:


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

* remove "loose" gke tests.  They are not used in production any more.
* create a new gke deployment file in test/bookstore/backend.yaml_temp
* 