### PR TITLE
Fix e2e test by switching to new SA key.

### DIFF
--- a/script/all-utilities
+++ b/script/all-utilities
@@ -280,7 +280,7 @@ function activate_service_account() {
   local local_json="$(mktemp /tmp/XXXXXX.secret.json)"
   case "${project}" in
     esp-load-test)
-      remote_json_name='esp-load-test-d07065e7da9063cc.json'
+      remote_json_name='esp-load-test-8bf830ba292a.json'
       service_account='service-control-in-load-test@esp-load-test.iam.gserviceaccount.com'
       ;;
     esp-long-run)


### PR DESCRIPTION
The old key was expired. Created a new key for service-control-in-load-test@esp-load-test.iam.gserviceaccount.com.