### PR TITLE
Default enable_api_key_uid_reporting to true

### DIFF
--- a/start_esp/server-auto.conf.template
+++ b/start_esp/server-auto.conf.template
@@ -65,7 +65,7 @@ service_control_config {
   %if service_control_network_fail_open:
   network_fail_open: true
   % endif
-  % if enable_api_key_uid_reporting:
+  % if enable_api_key_uid_reporting == True:
   enable_api_key_uid_reporting: true
 % endif
 }

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -954,8 +954,9 @@ config file.'''.format(
         If number of ESP instances for a service is big, please increase this number.''')
 
     parser.add_argument('--enable_api_key_uid_reporting', default=True,
-                        help='''If set to true, reports api_key_uid instead of api_key in
-                        ServiceControl report.''')
+                        help='''Default to true to report api_key_uid.
+                        If set to false, reports api_key instead of api_key_uid
+                        in ServiceControl report.''')
 
     return parser
 

--- a/start_esp/start_esp.py
+++ b/start_esp/start_esp.py
@@ -952,8 +952,8 @@ config file.'''.format(
         to call at the same time to exceed the quota, the calling time is throttled within
         a window. This flag specifies the throttle window in seconds. Default is 5 minutes.
         If number of ESP instances for a service is big, please increase this number.''')
-    
-    parser.add_argument('--enable_api_key_uid_reporting', action='store_true',
+
+    parser.add_argument('--enable_api_key_uid_reporting', default=True,
                         help='''If set to true, reports api_key_uid instead of api_key in
                         ServiceControl report.''')
 

--- a/start_esp/test/start_esp_test.py
+++ b/start_esp/test/start_esp_test.py
@@ -371,9 +371,9 @@ class TestStartEsp(unittest.TestCase):
             return_code = os.system(config_generator)
             self.assertEqual(return_code >> 8, 3)
 
-    def test_enable_api_key_uid_reporting(self):
-        expected_config_file = "./start_esp/test/testdata/expected_enable_api_key_uid_reporting.json"
-        config_generator = self.basic_config_generator + " --enable_api_key_uid_reporting"
+    def test_no_enable_api_key_uid_reporting(self):
+        expected_config_file = "./start_esp/test/testdata/expected_no_enable_api_key_uid_reporting.json"
+        config_generator = self.basic_config_generator + " --enable_api_key_uid_reporting False"
         self.run_test_with_expectation(expected_config_file, self.generated_server_config_file, config_generator)
 
 if __name__ == '__main__':

--- a/start_esp/test/testdata/expected_client_ip_header_server.json
+++ b/start_esp/test/testdata/expected_client_ip_header_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 client_ip_extraction_config {
   client_ip_header: "test_ip_header"

--- a/start_esp/test/testdata/expected_client_ip_position_server.json
+++ b/start_esp/test/testdata/expected_client_ip_position_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 client_ip_extraction_config {
   client_ip_header: "test_ip_header"

--- a/start_esp/test/testdata/expected_cloud_trace_url_override_server.json
+++ b/start_esp/test/testdata/expected_cloud_trace_url_override_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_compute_platform_override_server.json
+++ b/start_esp/test/testdata/expected_compute_platform_override_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_disable_cloud_trace_auto_sampling_server.json
+++ b/start_esp/test/testdata/expected_disable_cloud_trace_auto_sampling_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_grpc_backend_ssl_client_key_server.json
+++ b/start_esp/test/testdata/expected_grpc_backend_ssl_client_key_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_grpc_backend_ssl_enable_server.json
+++ b/start_esp/test/testdata/expected_grpc_backend_ssl_enable_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_grpc_backend_ssl_root_certs_server.json
+++ b/start_esp/test/testdata/expected_grpc_backend_ssl_root_certs_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_jwks_cache_duration.json
+++ b/start_esp/test/testdata/expected_jwks_cache_duration.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 api_authentication_config {
   jwks_cache_duration_in_s: 1000

--- a/start_esp/test/testdata/expected_management_server.json
+++ b/start_esp/test/testdata/expected_management_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_no_enable_api_key_uid_reporting.json
+++ b/start_esp/test/testdata/expected_no_enable_api_key_uid_reporting.json
@@ -33,7 +33,6 @@ service_management_config {
 }
 service_control_config {
     network_fail_open: true
-    enable_api_key_uid_reporting: true
 }
 experimental {
     disable_log_status: true

--- a/start_esp/test/testdata/expected_redirect_authorization_url.json
+++ b/start_esp/test/testdata/expected_redirect_authorization_url.json
@@ -33,6 +33,7 @@ service_management_config {
 }
 service_control_config {
     network_fail_open: true
+    enable_api_key_uid_reporting: true
 }
 api_authentication_config {
     redirect_authorization_url: true

--- a/start_esp/test/testdata/expected_rewrite_server.json
+++ b/start_esp/test/testdata/expected_rewrite_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_rollout_fetch_throttle_window.json
+++ b/start_esp/test/testdata/expected_rollout_fetch_throttle_window.json
@@ -35,6 +35,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_rollout_strategy_server.json
+++ b/start_esp/test/testdata/expected_rollout_strategy_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_service_control_log_entries.json
+++ b/start_esp/test/testdata/expected_service_control_log_entries.json
@@ -39,6 +39,7 @@ service_control_config {
   log_jwt_payload: "foo"
   log_jwt_payload: "bar.sub_bar"
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_service_control_network_fail_open.json
+++ b/start_esp/test/testdata/expected_service_control_network_fail_open.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_service_control_url_override_server.json
+++ b/start_esp/test/testdata/expected_service_control_url_override_server.json
@@ -35,6 +35,7 @@ service_management_config {
 service_control_config {
   url_override: "test_url_override"
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_transcoding_always_print_primitive_fields_server.json
+++ b/start_esp/test/testdata/expected_transcoding_always_print_primitive_fields_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true

--- a/start_esp/test/testdata/expected_transcoding_preserve_proto_field_names_server.json
+++ b/start_esp/test/testdata/expected_transcoding_preserve_proto_field_names_server.json
@@ -34,6 +34,7 @@ service_management_config {
 }
 service_control_config {
   network_fail_open: true
+  enable_api_key_uid_reporting: true
 }
 experimental {
   disable_log_status: true


### PR DESCRIPTION
- Can pass`bazel test //start_esp/test:start_esp_test` 
- Built the image manually and manually checked ESPv1 with API key UUID change